### PR TITLE
消除 nju09 下大多数的编译警告

### DIFF
--- a/nju09/www/bbs0an.c
+++ b/nju09/www/bbs0an.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static int getvisit(int n[2], const char *path);
+
 int
 anc_readtitle(FILE * fp, char *title, int size)
 {
@@ -39,10 +41,10 @@ anc_readitem(FILE * fp, char *path, int sizepath, char *name, int sizename)
 int
 anc_hidetitle(char *title)
 {
-	if (!(currentuser.userlevel & PERM_SYSOP) &&
-	    (strstr(title, "(BM: SYSOPS)") != NULL
-	     || strstr(title, "(BM: SECRET)") != NULL
-	     || strstr(title, "(BM: BMS)") != NULL))
+	if (!(currentuser.userlevel & PERM_SYSOP)
+			&& (strstr(title, "(BM: SYSOPS)") != NULL
+				|| strstr(title, "(BM: SECRET)") != NULL
+				|| strstr(title, "(BM: BMS)") != NULL))
 		return 1;
 	if (strstr(title, "<HIDE>") != NULL)
 		return 1;
@@ -54,8 +56,7 @@ bbs0an_main()
 {	//modify by mintbaggio 040825 for new www
 	FILE *fp;
 	int index = 0, visit[2];
-	char *ptr, papath[PATHLEN], path[PATHLEN], names[PATHLEN],
-	    file[80], buf[PATHLEN], title[256] = " ";
+	char *ptr, papath[PATHLEN], path[PATHLEN], names[PATHLEN], file[80], buf[PATHLEN], title[256] = " ";
 	char *board;
 	html_header(1);
 	changemode(DIGEST);
@@ -98,9 +99,9 @@ L:	fp = fopen(names, "r");
 	getvisit(visit, path);
 	title[38] = 0;
 	printf("<td height=35>%s &gt;<span id=topmenu_b>%s精华区</span> [本目录浏览统计: <span class=themetext> %4d</span>次<span class=themetext>%4d</span>%s]</td>\n",
-	       BBSNAME, buf, visit[0],
-	       (visit[1] > 100000) ? (visit[1] / 3600) : (visit[1] / 60),
-	       (visit[1] > 100000) ? "时" : "分");
+			BBSNAME, buf, visit[0],
+			(visit[1] > 100000) ? (visit[1] / 3600) : (visit[1] / 60),
+			(visit[1] > 100000) ? "时" : "分");
 	printf("</tr>");
 	if (papath[0])
 		printf("<tr><td height=35 valign=top><a href=bbs0an?path=%s class=btnsubmittheme title=\"返回上层目录\" accesskey: b\" accesskey=\"b\">返回上层目录</a></td></tr>\n",
@@ -112,74 +113,61 @@ L:	fp = fopen(names, "r");
 	printf("<tbody>\n");
 
 	printf("<tr><td class=tdtitle colspan=5>%s</td></tr>", nohtml(void1(title)));
-	printf
-    		("<tr><td class=tdtitle>编号</td><td class=tdtitle>类别</td><td class=tdtitle>标题</td><td class=tdtitle>整理人</td><td class=tdtitle>日期</td></tr>");
+	printf("<tr><td class=tdtitle>编号</td><td class=tdtitle>类别</td><td class=tdtitle>标题</td><td class=tdtitle>整理人</td><td class=tdtitle>日期</td></tr>");
 	while (!anc_readitem(fp, file, sizeof (file), title, sizeof (title))) {
-	char *id;
-	if (anc_hidetitle(title))
-		continue;
-	snprintf(buf, sizeof (buf), "%s%s", path, file);
-	if(strcasecmp(board, "PersonalCorpus")){	//add by mintbaggio@BMY for the reason of www PersonalCorpus
-		ptr = getbfroma(buf);
-		if (*ptr && !has_read_perm(&currentuser, ptr))
+		char *id;
+		if (anc_hidetitle(title))
 			continue;
-	}
-	index++;
-	if (strlen(title) <= 39)
-		id = "";
-	else {
-		title[38] = 0;
-		id = title + 39;
-		if (!strncmp(id, "BM: ", 4))
-			id += 4;
-		ptr = strchr(id, ')');
-		if (ptr)
-			ptr[0] = 0;
-	}
-	printf("<tr><td class=tdborder>%d</td>", index);
-	snprintf(buf, sizeof (buf), "0Announce%s%s", path, file);
-	/*if(access("/home/bbs/0Announce/", F_OK)<0)		//test by mintbaggio
-		printf("errno=%d, ft!!\n", errno);
-	else	printf("good!!\n");*/
-	if (!file_exist(buf)) {
-		printf("<td class=tdborder>[错误]</td><td class=tdborder>%s</td>", void1(titlestr(title)));
-	} else/*bjgyt*/ if (file_isdir(buf)) {
-		printf
-		    ("<td class=tdborder>[目录]</td><td class=tdborder><a href=bbs0an?path=%s%s>%s</a></td>",
-		     path, file, void1(titlestr(title)));
-	} else {
-		printf
-		    ("<td class=tdborder>[文件]</td><td class=tdborder><a href=bbsanc?path=%s&item=%s>%s</a></td>",
-		     path, file, void1(titlestr(title)));
-	}
-	if (id[0])
-		printf("<td class=tdborder>%s</td>", userid_str(id));
-	else
-		printf("<td  class=tdborder> </td>");
-	printf("<td>%6.6s %s</td></tr>", ytht_ctime(file_time(buf)) + 4,
-		   ytht_ctime(file_time(buf)) + 20);
+		snprintf(buf, sizeof (buf), "%s%s", path, file);
+		if(strcasecmp(board, "PersonalCorpus")){	//add by mintbaggio@BMY for the reason of www PersonalCorpus
+			ptr = getbfroma(buf);
+			if (*ptr && !has_read_perm(&currentuser, ptr))
+				continue;
+		}
+		index++;
+		if (strlen(title) <= 39)
+			id = "";
+		else {
+			title[38] = 0;
+			id = title + 39;
+			if (!strncmp(id, "BM: ", 4))
+				id += 4;
+			ptr = strchr(id, ')');
+			if (ptr)
+				ptr[0] = 0;
+		}
+		printf("<tr><td class=tdborder>%d</td>", index);
+		snprintf(buf, sizeof (buf), "0Announce%s%s", path, file);
+		if (!file_exist(buf)) {
+			printf("<td class=tdborder>[错误]</td><td class=tdborder>%s</td>", void1(titlestr(title)));
+		} else/*bjgyt*/ if (file_isdir(buf)) {
+			printf("<td class=tdborder>[目录]</td><td class=tdborder><a href=bbs0an?path=%s%s>%s</a></td>", path, file, void1(titlestr(title)));
+		} else {
+			printf("<td class=tdborder>[文件]</td><td class=tdborder><a href=bbsanc?path=%s&item=%s>%s</a></td>", path, file, void1(titlestr(title)));
+		}
+		if (id[0])
+			printf("<td class=tdborder>%s</td>", userid_str(id));
+		else
+			printf("<td  class=tdborder> </td>");
+		printf("<td>%6.6s %s</td></tr>", ytht_ctime(file_time(buf)) + 4,
+				ytht_ctime(file_time(buf)) + 20);
 
-}
-fclose(fp);
-printf("</tr></tbody>");
-printf("</table></td></tr></table></td></tr></table>");
+	}
+	fclose(fp);
+	printf("</tr></tbody>");
+	printf("</table></td></tr></table></td></tr></table>");
 	if (index <= 0) {
 		printf("<br>&lt;&lt; 目前没有文章 &gt;&gt;\n");
 	}
 	if (papath[0])
-		printf("<br>[<a href=bbs0an?path=%s>返回上一层目录</a>] ",
-		       papath);
+		printf("<br>[<a href=bbs0an?path=%s>返回上一层目录</a>] ", papath);
 	else
-		printf
-		    ("<br>[<a href='javascript:history.go(-1)'>返回上一页</a>] ");
+		printf("<br>[<a href='javascript:history.go(-1)'>返回上一页</a>] ");
 	if (board[0]) {
 		printf("[<a href=%s%s>本讨论区</a>] ", showByDefMode(), board);
-/*		printf
-		    ("[<a href=\"ftp://" MY_BBS_DOMAIN
-		     ":2121/pub/X/%s.tgz\">下载精华区</a>]", board);
+/*		printf("[<a href=\"ftp://" MY_BBS_DOMAIN ":2121/pub/X/%s.tgz\">下载精华区</a>]", board);
 */
-		printf
-		    ("[<a href=bbsx/%s.tgz>下载精华区</a>]", board);
+		printf("[<a href=bbsx/%s.tgz>下载精华区</a>]", board);
 	}
 
 printf("</body>");
@@ -187,15 +175,12 @@ http_quit();
 return 0;
 }
 
-int
-getvisit(int n[2], const char *path)
-{
+static int getvisit(int n[2], const char *path) {
 	char fn[PATH_MAX + 1];
 	int fd;
 	n[0] = 0;
 	n[1] = 0;
-	if (snprintf(fn, PATH_MAX + 1, "0Announce%s/.logvisit", path) >
-	    PATH_MAX)
+	if (snprintf(fn, PATH_MAX + 1, "0Announce%s/.logvisit", path) > PATH_MAX)
 		return -1;
 	fd = open(fn, O_RDONLY | O_CREAT, 0660);
 	if (fd < 0)

--- a/nju09/www/bbs0an.c
+++ b/nju09/www/bbs0an.c
@@ -56,7 +56,7 @@ bbs0an_main()
 {	//modify by mintbaggio 040825 for new www
 	FILE *fp;
 	int index = 0, visit[2];
-	char *ptr, papath[PATHLEN], path[PATHLEN], names[PATHLEN], file[80], buf[PATHLEN], title[256] = " ";
+	char *ptr, papath[PATHLEN], path[PATHLEN], names[PATHLEN + STRLEN], file[80], buf[PATHLEN + STRLEN * 2], title[256] = " ";
 	char *board;
 	html_header(1);
 	changemode(DIGEST);
@@ -68,7 +68,7 @@ bbs0an_main()
 	ytht_strsncpy(path, getparm("path"), PATHLEN - 1);
 	if (strstr(path, ".."))
 		http_fatal("此目录不存在");
-	snprintf(names, PATHLEN, "0Announce%s/.Names", path);
+	snprintf(names, sizeof(names), "0Announce%s/.Names", path);
 	strcpy(papath, path);
 	ptr = strrchr(papath, '/');
 	if (ptr != NULL) {
@@ -82,7 +82,8 @@ bbs0an_main()
 		goto L;
 	if (board[0] && !has_read_perm(&currentuser, board))
 		http_fatal("1,目录不存在");
-L:	fp = fopen(names, "r");
+L:
+	fp = fopen(names, "r");
 	if (fp == 0)
 		http_fatal("2,目录不存在");
 	if (anc_readtitle(fp, title, sizeof (title))) {

--- a/nju09/www/bbsanc.c
+++ b/nju09/www/bbsanc.c
@@ -11,8 +11,8 @@ extern int anc_hidetitle(char *title);
 int
 bbsanc_main()
 {	//modify by mintbaggio 20040829 for new www
-	char *board, *ptr, path[PATHLEN], fn[PATHLEN], buf[PATHLEN],
-	item[PATHLEN], names[PATHLEN], file[80], lastfile[80], title[256] = " ";
+	char *board, *ptr, path[PATHLEN], fn[PATHLEN * 2 + STRLEN], buf[PATHLEN],
+	item[PATHLEN], names[PATHLEN + STRLEN], file[80], lastfile[80], title[256] = " ";
 	int index = 0, found = 0;
 	FILE *fp;
 	changemode(DIGEST);
@@ -29,7 +29,7 @@ L:
 		sprintf(buf, "%s版", board);
 	if (strstr(path, ".Search") || strstr(path, ".Names") || strstr(path, ".."))
 		http_fatal("错误的文件名");
-	snprintf(names, PATHLEN, "0Announce%s/.Names", path);
+	snprintf(names, sizeof(names), "0Announce%s/.Names", path);
 	fp = fopen(names, "r");
 	if (fp == 0)
 		http_fatal("目录不存在");
@@ -63,7 +63,7 @@ L:
 		fclose(fp);
 		http_fatal("文件不存在");
 	}
-	snprintf(fn, PATHLEN, "0Announce%s%s", path, item);
+	snprintf(fn, sizeof(fn), "0Announce%s%s", path, item);
 	if (*getparm("attachname") == '/') {
 		fclose(fp);
 		showbinaryattach(fn);
@@ -77,7 +77,7 @@ L:
 	printf("</div><hr>");
 	showcon(fn);
 	if (index > 0) {
-		snprintf(fn, PATHLEN, "0Announce%s%s", path, lastfile);
+		snprintf(fn, sizeof(fn), "0Announce%s%s", path, lastfile);
 		if (file_exist(fn)) {
 			if (file_isdir(fn)) {
 				printf("[<a href=bbs0an?path=%s%s>上一项</a>] ", path, lastfile);
@@ -91,7 +91,7 @@ L:
 		if (anc_readitem(fp, file, sizeof (file), title, sizeof (title))) break;
 		if (anc_hidetitle(title))
 			break;
-		snprintf(fn, PATHLEN, "0Announce%s%s", path, file);
+		snprintf(fn, sizeof(fn), "0Announce%s%s", path, file);
 		if (!board[0]) {
 			if(strcasecmp(board, "PersonalCorpus")){	//add by mintbaggio@BMY for the reason of www PersonalCorpus
 				ptr = getbfroma(buf);

--- a/nju09/www/bbsanc.c
+++ b/nju09/www/bbsanc.c
@@ -1,11 +1,18 @@
 #include "bbslib.h"
 
+// bbscon.c
+extern int showbinaryattach(char *filename);
+
+// bbs0an
+extern int anc_readtitle(FILE * fp, char *title, int size);
+extern int anc_readitem(FILE * fp, char *path, int sizepath, char *name, int sizename);
+extern int anc_hidetitle(char *title);
+
 int
 bbsanc_main()
 {	//modify by mintbaggio 20040829 for new www
 	char *board, *ptr, path[PATHLEN], fn[PATHLEN], buf[PATHLEN],
-	    item[PATHLEN], names[PATHLEN], file[80], lastfile[80], title[256] =
-	    " ";
+	item[PATHLEN], names[PATHLEN], file[80], lastfile[80], title[256] = " ";
 	int index = 0, found = 0;
 	FILE *fp;
 	changemode(DIGEST);
@@ -16,11 +23,11 @@ bbsanc_main()
 		goto L;
 	if (board[0] && !has_read_perm(&currentuser, board))
 		http_fatal("目录不存在");
-L:	buf[0] = 0;
+L:
+	buf[0] = 0;
 	if (board[0])
 		sprintf(buf, "%s版", board);
-	if (strstr(path, ".Search") || strstr(path, ".Names")
-	    || strstr(path, ".."))
+	if (strstr(path, ".Search") || strstr(path, ".Names") || strstr(path, ".."))
 		http_fatal("错误的文件名");
 	snprintf(names, PATHLEN, "0Announce%s/.Names", path);
 	fp = fopen(names, "r");
@@ -73,20 +80,15 @@ L:	buf[0] = 0;
 		snprintf(fn, PATHLEN, "0Announce%s%s", path, lastfile);
 		if (file_exist(fn)) {
 			if (file_isdir(fn)) {
-				printf
-				    ("[<a href=bbs0an?path=%s%s>上一项</a>] ",
-				     path, lastfile);
+				printf("[<a href=bbs0an?path=%s%s>上一项</a>] ", path, lastfile);
 			} else {
-				printf
-				    ("[<a href=bbsanc?path=%s&item=%s>上一项</a>] ",
-				     path, lastfile);
+				printf("[<a href=bbsanc?path=%s&item=%s>上一项</a>] ", path, lastfile);
 			}
 		}
 	}
 	printf("[<a href=bbs0an?path=%s>回到目录</a>] ", path);
 	while (1) {
-		if (anc_readitem
-		    (fp, file, sizeof (file), title, sizeof (title))) break;
+		if (anc_readitem(fp, file, sizeof (file), title, sizeof (title))) break;
 		if (anc_hidetitle(title))
 			break;
 		snprintf(fn, PATHLEN, "0Announce%s%s", path, file);
@@ -99,13 +101,9 @@ L:	buf[0] = 0;
 		}
 		if (file_exist(fn)) {
 			if (file_isdir(fn)) {
-				printf
-				    ("[<a href=bbs0an?path%s%s>下一项</a>] ",
-				     path, file);
+				printf("[<a href=bbs0an?path%s%s>下一项</a>] ", path, file);
 			} else {
-				printf
-				    ("[<a href=bbsanc?path=%s&item=%s>下一项</a>] ",
-				     path, file);
+				printf("[<a href=bbsanc?path=%s&item=%s>下一项</a>] ", path, file);
 			}
 		}
 		break;

--- a/nju09/www/bbsattach.c
+++ b/nju09/www/bbsattach.c
@@ -1,6 +1,8 @@
 #include "bbslib.h"
 #include "check_server.h"
 
+extern struct cgi_applet *get_cgi_applet(char *needcgi);
+
 int
 bbsattach_main()
 {

--- a/nju09/www/bbsbadlogins.c
+++ b/nju09/www/bbsbadlogins.c
@@ -11,7 +11,7 @@ bbsbadlogins_main()
 		return 0;
 	}
 
-	sethomefile(file, currentuser.userid, BADLOGINFILE);
+	sethomefile_s(file, sizeof(file), currentuser.userid, BADLOGINFILE);
 	if (!file_exist(file)) {
 		printf("没有任何密码输入错误记录</body></html>");
 		return 0;
@@ -19,8 +19,7 @@ bbsbadlogins_main()
 	if (*getparm("del") == '1') {
 		unlink(file);
 		printf("密码输入错误记录已被删除<br>");
-		printf
-		    ("<a href='#' onClick='javascript:window.close()'>关闭窗口</a>");
+		printf("<a href='#' onClick='javascript:window.close()'>关闭窗口</a>");
 	} else {
 		printf("发现以下密码输入错误记录<br><pre>");
 		showfile(file);

--- a/nju09/www/bbsbfind.c
+++ b/nju09/www/bbsbfind.c
@@ -7,7 +7,7 @@ bbsbfind_main()
 {
 	FILE *fp;
 	int num = 0, total = 0, type, dt, mg = 0, og = 0, at = 0;
-	char dir[80], title[80], title2[80], title3[80], board[80], userid[80];
+	char dir[80], title[80], title2[80], title3[80], board[32], userid[80];
 	struct boardmem *brd;
 	struct fileheader x;
 	html_header(1);
@@ -15,9 +15,9 @@ bbsbfind_main()
 	check_msg();
 	printf("<center>%s -- °æÄÚÎÄÕÂËÑË÷<hr>\n", BBSNAME);
 	type = atoi(getparm("type"));
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 30);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	if (type == 0)
 		return show_form(board);
 	// Ò»°ãËÑË÷
@@ -105,9 +105,9 @@ bbsbfind_main()
 
 	{
 		char content[200];
-		char cmd[256];
+		char cmd[512];
 		ytht_strsncpy(content, getparm("content"), 200);
-		sprintf(cmd, MY_BBS_HOME "/bin/searcher.py %s '%s'", board, content);
+		snprintf(cmd, sizeof(cmd), MY_BBS_HOME "/bin/searcher.py %s '%s'", board, content);
 
 		brd = getboard(board);
 		if (brd == 0)

--- a/nju09/www/bbsbkncon.c
+++ b/nju09/www/bbsbkncon.c
@@ -1,11 +1,13 @@
 #include "bbslib.h"
 
+extern int showbinaryattach(char *filename);
+
 int
 bbsbkncon_main()
 {
 	char board[80], bkn[80], dir[256], file[256], filename[256], *ptr;
 	struct fileheader *x, *dirinfo;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	int num, total;
 	changemode(BACKNUMBER);
 	ytht_strsncpy(board, getparm("board"), 32);
@@ -49,9 +51,7 @@ bbsbkncon_main()
 			MMAP_UNTRY;
 			http_fatal("本文不存在或者已被删除");
 		}
-		dirinfo =
-		    (struct fileheader *) (mf.ptr +
-					   num * sizeof (struct fileheader));
+		dirinfo = (struct fileheader *) (mf.ptr + num * sizeof (struct fileheader));
 		if (dirinfo->owner[0] == '-') {
 			mmapfile(NULL, &mf);
 			MMAP_UNTRY;
@@ -68,29 +68,18 @@ bbsbkncon_main()
 			http_fatal("编号不太对啊...");
 		}
 		showcon(filename);
-		printf("[<a href=bbsfwd?board=%s&file=%s>转寄</a>]", board,
-		       file);
-		printf("[<a href=bbsccc?board=%s&file=%s>转贴</a>]", board,
-		       file);
+		printf("[<a href=bbsfwd?board=%s&file=%s>转寄</a>]", board, file);
+		printf("[<a href=bbsccc?board=%s&file=%s>转贴</a>]", board, file);
 		if (num > 0) {
-			x = (struct fileheader *) (mf.ptr +
-						   (num -
-						    1) *
-						   sizeof (struct fileheader));
-			printf
-			    ("[<a href=bbsbkncon?board=%s&bkn=%s&file=%s&num=%d>上一篇</a>]",
-			     board, bkn, fh2fname(x), num - 1);
+			x = (struct fileheader *) (mf.ptr + (num - 1) * sizeof (struct fileheader));
+			printf("[<a href=bbsbkncon?board=%s&bkn=%s&file=%s&num=%d>上一篇</a>]",
+					board, bkn, fh2fname(x), num - 1);
 		}
-		printf("[<a href=bbsbkndoc?board=%s&bkn=%s>本卷过刊</a>]",
-		       board, bkn);
+		printf("[<a href=bbsbkndoc?board=%s&bkn=%s>本卷过刊</a>]", board, bkn);
 		if (num < total - 1) {
-			x = (struct fileheader *) (mf.ptr +
-						   (num +
-						    1) *
-						   sizeof (struct fileheader));
-			printf
-			    ("[<a href=bbsbkncon?board=%s&bkn=%s&file=%s&num=%d>下一篇</a>]",
-			     board, bkn, fh2fname(x), num + 1);
+			x = (struct fileheader *) (mf.ptr + (num + 1) * sizeof (struct fileheader));
+			printf("[<a href=bbsbkncon?board=%s&bkn=%s&file=%s&num=%d>下一篇</a>]",
+					board, bkn, fh2fname(x), num + 1);
 		}
 	}
 	MMAP_CATCH {

--- a/nju09/www/bbsbkncon.c
+++ b/nju09/www/bbsbkncon.c
@@ -5,14 +5,14 @@ extern int showbinaryattach(char *filename);
 int
 bbsbkncon_main()
 {
-	char board[80], bkn[80], dir[256], file[256], filename[256], *ptr;
+	char board[32], bkn[32], dir[256], file[32], filename[256], *ptr;
 	struct fileheader *x, *dirinfo;
 	struct mmapfile mf = { .ptr = NULL };
 	int num, total;
 	changemode(BACKNUMBER);
-	ytht_strsncpy(board, getparm("board"), 32);
-	ytht_strsncpy(bkn, getparm("bkn"), 32);
-	ytht_strsncpy(file, getparm("file"), 32);
+	ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(bkn, getparm("bkn"), sizeof(bkn));
+	ytht_strsncpy(file, getparm("file"), sizeof(file));
 	num = atoi(getparm("num"));
 	ptr = bkn;
 	while (*ptr) {

--- a/nju09/www/bbsbkndoc.c
+++ b/nju09/www/bbsbkndoc.c
@@ -11,17 +11,17 @@ int
 bbsbkndoc_main()
 {
 	FILE *fp;
-	char board[80], bkn[80], dir[160], *ptr, genbuf[STRLEN];
+	char board[32], bkn[32], dir[160], *ptr, genbuf[STRLEN * 2];
 	struct boardmem *x1;
 	struct fileheader x;
 	int i, start, total;
 	html_header(1);
 	changemode(BACKNUMBER);
 	check_msg();
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
-	ytht_strsncpy(bkn, getparm("bkn"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(bkn, getparm("bkn"), sizeof(bkn));
 	ptr = bkn;
 	while (*ptr) {
 		if (*ptr != 'B' && *ptr != '.' && !isdigit(*ptr))
@@ -49,7 +49,7 @@ bbsbkndoc_main()
 		printboardtop(x1, 5);
 		printf("阅览过刊 文章数[%d] ", total);
 		printf("<a href=bbsbknsel?board=%s>选择过刊</a> ", board);
-		sprintf(genbuf, "bbsbkndoc?board=%s&bkn=%s", board, bkn);
+		snprintf(genbuf, sizeof(genbuf), "bbsbkndoc?board=%s&bkn=%s", board, bkn);
 		bbsdoc_helper(genbuf, start, total, w_info->t_lines);
 		if (total <= 0)
 			http_fatal("本卷过刊目前没有文章");

--- a/nju09/www/bbsbknsel.c
+++ b/nju09/www/bbsbknsel.c
@@ -1,5 +1,11 @@
 #include "bbslib.h"
 
+extern void nosuchboard(char *board, char *cginame);
+extern void printboardtop(struct boardmem *x, int num);
+extern int getdocstart(int total, int lines);
+extern void bbsdoc_helper(char *cgistr, int start, int total, int lines);
+extern void printdocform(char *cginame, char *board);
+
 int
 bbsbknsel_main()
 {
@@ -37,26 +43,20 @@ bbsbknsel_main()
 			http_fatal("本讨论区目前没有过刊");
 		}
 		printf("<table>\n");
-		printf
-		    ("<tr><td>序号</td><td>讨论区</td><td>建立日期</td><td>标题　　　　　　　　　　　　　　</td></tr>\n");
+		printf("<tr><td>序号</td><td>讨论区</td><td>建立日期</td><td>标题</td></tr>\n");
 		if (fp) {
-			fseek(fp, (start - 1) * sizeof (struct bknheader),
-			      SEEK_SET);
+			fseek(fp, (start - 1) * sizeof (struct bknheader), SEEK_SET);
 			for (i = 0; i < w_info->t_lines; i++) {
 				if (fread(&x, sizeof (x), 1, fp) <= 0)
 					break;
-				printf("<tr><td>%d</td><td>%s</td>",
-				       start + i, x.boardname);
+				printf("<tr><td>%d</td><td>%s</td>", start + i, x.boardname);
 				if (!i)
-					printf("<td><nobr>%12.12s</td>",
-						   ytht_ctime(x.filetime) + 4);
+					printf("<td><nobr>%12.12s</td>", ytht_ctime(x.filetime) + 4);
 				else
-					printf("<td>%12.12s</td>",
-						   ytht_ctime(x.filetime) + 4);
-				printf
-				    ("<td><a href=bbsbkndoc?board=%s&bkn=%s&num=%d>○ %s </a></td></tr>",
-				     board, bknh2bknname(&x), start + i - 1,
-				     void1(titlestr(x.title)));
+					printf("<td>%12.12s</td>", ytht_ctime(x.filetime) + 4);
+				printf("<td><a href=bbsbkndoc?board=%s&bkn=%s&num=%d>○ %s </a></td></tr>",
+						board, bknh2bknname(&x), start + i - 1,
+						void1(titlestr(x.title)));
 			}
 			printf("</table>");
 			printhr();

--- a/nju09/www/bbsbknsel.c
+++ b/nju09/www/bbsbknsel.c
@@ -10,7 +10,7 @@ int
 bbsbknsel_main()
 {
 	FILE *fp;
-	char board[80], dir[160], genbuf[STRLEN];
+	char board[32], dir[160], genbuf[STRLEN];
 	struct boardmem *x1;
 	struct bknheader x;
 	int i, start, total;
@@ -18,9 +18,9 @@ bbsbknsel_main()
 	printf("<script src=/function.js></script>\n");
 	check_msg();
 	changemode(SELBACKNUMBER);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	x1 = getboard(board);
 	if (x1 == 0)
 		nosuchboard(board, "bbsbknsel");

--- a/nju09/www/bbsccc.c
+++ b/nju09/www/bbsccc.c
@@ -7,18 +7,18 @@ bbsccc_main()
 {
 	struct fileheader *x = NULL;
 	struct boardmem *brd, *brd1;
-	char board[80], file[80], target[80];
+	char board[32], file[30], target[80];
 	char dir[80];
 	struct mmapfile mf = { .ptr = NULL };
 	int num;
 	html_header(1);
 	check_msg();
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 30);
-	ytht_strsncpy(file, getparm("F"), 30);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 30);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	ytht_strsncpy(target, getparm("target"), 30);
 	if (!loginok || isguest)
 		http_fatal("匆匆过客不能进行本项操作");

--- a/nju09/www/bbscccmail.c
+++ b/nju09/www/bbscccmail.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static int do_cccmail(struct fileheader *x, struct boardmem *brd);
+
 int
 bbscccmail_main()
 {
@@ -7,7 +9,7 @@ bbscccmail_main()
 	struct boardmem *brd;
 	char file[80], target[80];
 	char dir[80];
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	int num;
 	html_header(1);
 	check_msg();
@@ -33,8 +35,7 @@ bbscccmail_main()
 	MMAP_END mmapfile(NULL, &mf);
 	if (x == 0)
 		http_fatal("错误的文件名");
-	printf("<center>%s -- 转载文章 [使用者: %s]<hr>\n", BBSNAME,
-	       currentuser.userid);
+	printf("<center>%s -- 转载文章 [使用者: %s]<hr>\n", BBSNAME, currentuser.userid);
 	if (target[0]) {
 		brd = getboard(target);
 		if (brd == 0)
@@ -42,14 +43,12 @@ bbscccmail_main()
 		if (!has_post_perm(&currentuser, brd))
 			http_fatal("错误的讨论区名称或你没有在该版发文的权限");
 		if (noadm4political(target))
-			http_fatal
-			    ("对不起,因为没有版面管理人员在线,本版暂时封闭.");
+			http_fatal("对不起,因为没有版面管理人员在线,本版暂时封闭.");
 		return do_cccmail(x, brd);
 	}
 	printf("<table><tr><td>\n");
 	printf("<font color=red>转贴发文注意事项:<br>\n");
-	printf
-	    ("本站规定同样内容的文章严禁在3(不含)个以上讨论区重复张贴。");
+	printf("本站规定同样内容的文章严禁在3(不含)个以上讨论区重复张贴。");
 	printf("违者将剥夺全站发表文章的权利。<br><br></font>\n");
 	printf("文章标题: %s<br>\n", nohtml(x->title));
 	printf("文章作者: %s<br>\n", fh2owner(x));
@@ -61,12 +60,9 @@ bbscccmail_main()
 	return 0;
 }
 
-int
-do_cccmail(struct fileheader *x, struct boardmem *brd)
-{
+static int do_cccmail(struct fileheader *x, struct boardmem *brd) {
 	FILE *fp, *fp2;
-	char board[80], title[512], buf[512], path[200], path2[200],
-	    i;
+	char board[80], title[512], buf[512], path[200], path2[200], i;
 	char tmpfn[80];
 	int retv;
 	int mark = 0;
@@ -123,8 +119,8 @@ do_cccmail(struct fileheader *x, struct boardmem *brd)
 	}
 	unlink(tmpfn);
 	post_article(board, title, path2, currentuser.userid,
-		     currentuser.username, fromhost, -1, mark, 0,
-		     currentuser.userid, -1);
+			currentuser.username, fromhost, -1, mark, 0,
+			currentuser.userid, -1);
 	unlink(path2);
 	printf("'%s' 已转贴到 %s 版.<br>\n", nohtml(title), board);
 	printf("[<a href='javascript:history.go(-2)'>返回</a>]");

--- a/nju09/www/bbscon.c
+++ b/nju09/www/bbscon.c
@@ -6,9 +6,7 @@ extern char *cginame;
 int testmozilla(void);
 extern char *get_mime_type(const char *name);
 
-int
-showbinaryattach(char *filename)
-{
+int showbinaryattach(char *filename) {
 	char *attachname;
 	int pos_i;
 	size_t pos;

--- a/nju09/www/bbscon.c
+++ b/nju09/www/bbscon.c
@@ -226,7 +226,7 @@ showcon(char *filename)
 int
 showconxml(char *filename, int viewertype)
 {
-	char filetmp[200], cmd[200], *ptr, *pend;
+	char filetmp[200], cmd[512], *ptr, *pend;
 	struct mmapfile mf = { .ptr = NULL };
 	FILE *fp;
 	int retv = -1;
@@ -363,7 +363,7 @@ processMath()
 int
 bbscon_main()
 {	//modify by mintbaggio 050526 for new www
-	char board[80], dir[80], file[80], filename[80], fileback[80], *ptr;
+	char board[32 /* max 24 */], dir[80], file[32], filename[80], fileback[128], *ptr;
 	char buf[2048];
 	char bmbuf[IDLEN * 4 + 4];
 	int thread;
@@ -380,12 +380,12 @@ bbscon_main()
 
 	changemode(READING);
 
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
-	ytht_strsncpy(file, getparm("F"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 32);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	num = atoi((ptr = getparm("N"))) - 1;
 	if (!ptr[0])
 		num = atoi(getparm("num")) - 1;

--- a/nju09/www/bbscon1.c
+++ b/nju09/www/bbscon1.c
@@ -5,7 +5,7 @@ extern int showbinaryattach(char *filename);
 int
 bbscon1_main()
 {
-	char board[80], path[160], dir[80], file[80], filename[160], buf[80];
+	char board[80], path[160], dir[200], file[80], filename[320], buf[80];
 	struct fileheader *dirinfo = NULL;
 	int type, num;
 	char *ptr;

--- a/nju09/www/bbscon1.c
+++ b/nju09/www/bbscon1.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+extern int showbinaryattach(char *filename);
+
 int
 bbscon1_main()
 {
@@ -7,7 +9,7 @@ bbscon1_main()
 	struct fileheader *dirinfo = NULL;
 	int type, num;
 	char *ptr;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	changemode(READING);
 	type = atoi(getparm("T"));
 	switch (type) {

--- a/nju09/www/bbsdefcss.c
+++ b/nju09/www/bbsdefcss.c
@@ -14,7 +14,7 @@ bbsdefcss_main()
 	changemode(GMENU);
 	type = atoi(getparm("type"));
 	if (type > 0){
-		sethomefile(buf, currentuser.userid, "ubbs.css");
+		sethomefile_s(buf, sizeof(buf), currentuser.userid, "ubbs.css");
 		ptr=getparm("ucss");
 		f_write(buf,ptr);
 /*		sethomefile(buf, currentuser.userid, "uleft.css");
@@ -28,25 +28,22 @@ bbsdefcss_main()
 	printf("<tr><td>\n");
 	printf("<input type=hidden name=type value=1>");
 	printf("<span class=c31> 个人CSS模式允许用户自定义WWW的各种显示效果。<br>注意，下面是自于当前的界面[%s]所定义的CSS。<br>确定后将覆盖原有的所有自定义CSS。</span><br><br>\n",currstyle->name);
-	printf
-	     ("当前的CSS设置如下：<br><textarea name=ucss rows=20 cols=76>");
+	printf("当前的CSS设置如下：<br><textarea name=ucss rows=20 cols=76>");
 	if(strstr(currstyle->cssfile,"ubbs.css"))
-		sethomefile(buf, currentuser.userid, "ubbs.css");
+		sethomefile_s(buf, sizeof(buf), currentuser.userid, "ubbs.css");
 	else
 		sprintf(buf,HTMPATH "%s",currstyle->cssfile);
 	showfile(buf);
 	printf("</textarea><br>");
-/*	printf
-	     ("</textarea><br><br>当前的左侧选单的CSS设置如下(body.foot是底行的css)：<br><textarea name=uleftcss rows=5 cols=76>");
+/*	printf("</textarea><br><br>当前的左侧选单的CSS设置如下(body.foot是底行的css)：<br><textarea name=uleftcss rows=5 cols=76>");
 	if(strstr(currstyle->leftcssfile,"uleft.css"))
 		sethomefile(buf, currentuser.userid, "uleft.css");
 	else
 		sprintf(buf,HTMPATH "%s", currstyle->leftcssfile);
 	showfile(buf);
 	printf("</textarea><br><br>");*/
-	printf
-	    ("</textarea></td></tr><tr><td><input type=submit class=resetlong value=确定>"
-	    " <input type=reset class=sumbitlong value=复原>\n");
+	printf("</textarea></td></tr><tr><td><input type=submit class=resetlong value=确定>"
+			" <input type=reset class=sumbitlong value=复原>\n");
 	printf("</td></tr></form></table></body></html>\n");
 	return 0;
 }

--- a/nju09/www/bbsdel.c
+++ b/nju09/www/bbsdel.c
@@ -8,7 +8,7 @@ bbsdel_main()
 	//不原子
 	struct fileheader f;
 	struct userec *u;
-	char dir[80], board[80], file[80], *id;
+	char dir[80], board[32], file[80], *id;
 	int num = 0, filetime, total;
 	struct boardmem *x;
 	struct mmapfile mf = { .ptr = NULL };
@@ -18,9 +18,9 @@ bbsdel_main()
 		http_fatal("请先登录");
 	changemode(EDIT);
 	id = currentuser.userid;
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	ytht_strsncpy(file, getparm("F"), 30);
 	if (!file[0])
 		ytht_strsncpy(file, getparm("file"), 20);

--- a/nju09/www/bbsdelmail.c
+++ b/nju09/www/bbsdelmail.c
@@ -23,20 +23,20 @@ bbsdelmail_main()
 			ndelfile++;
 	}
 
-    int box_type = 0;
-    char type_string[20];
+	int box_type = 0;
+	char type_string[20];
 	ytht_strsncpy(type_string, getparm("box_type"), 20);
-    if(type_string[0] != 0) {
-        box_type = atoi(type_string);
-    }
-    snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
-    if(box_type == 1) {
-        setsentmailfile(path, currentuser.userid, ".DIR");
-	    setsentmailfile(tmppath, currentuser.userid, ".DIR.tmp");
-    } else {
-        setmailfile(path, currentuser.userid, ".DIR");
-        setmailfile(tmppath, currentuser.userid, ".DIR.tmp");
-    }
+	if(type_string[0] != 0) {
+		box_type = atoi(type_string);
+	}
+	snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
+	if(box_type == 1) {
+		setsentmailfile(path, currentuser.userid, ".DIR");
+		setsentmailfile(tmppath, currentuser.userid, ".DIR.tmp");
+	} else {
+		setmailfile_s(path, sizeof(path), currentuser.userid, ".DIR");
+		setmailfile_s(tmppath, sizeof(tmppath), currentuser.userid, ".DIR.tmp");
+	}
 	fp = fopen(path, "r");
 	if (fp == 0)
 		http_fatal("错误的参数2");
@@ -57,14 +57,13 @@ bbsdelmail_main()
 			fwrite(&f, sizeof (f), 1, fpw);
 			continue;
 		}
-		setmailfile(file, currentuser.userid, ptr);
+		setmailfile_s(file, sizeof(file), currentuser.userid, ptr);
 		unlink(file);
 	}
 	fclose(fp);
 	fclose(fpw);
 	rename(tmppath, path);
-	printf("信件已删除.<br><a href=bbsmail?%s>返回信件列表</a>\n"
-            , type_string);
+	printf("信件已删除.<br><a href=bbsmail?%s>返回信件列表</a>\n", type_string);
 	http_quit();
 	return 0;
 }

--- a/nju09/www/bbsdoc.c
+++ b/nju09/www/bbsdoc.c
@@ -39,9 +39,7 @@ static int nosuchboard_callback(struct boardmem *board, int curr_idx, va_list ap
 	return 0;
 }
 
-void
-nosuchboard(char *board, char *cginame)
-{
+void nosuchboard(char *board, char *cginame) {
 	int i, j = 0;
 	char buf[128];
 	printf("没有这个讨论区啊，可能的选择:<p>");

--- a/nju09/www/bbsdoc.c
+++ b/nju09/www/bbsdoc.c
@@ -197,14 +197,14 @@ int
 bbsdoc_main()
 {	//modify by mintbaggio 040522 for new www
 	FILE *fp;
-	char board[80], dir[80], genbuf[STRLEN], buf[STRLEN],only_for_b[80];
+	char board[32 /* max: 24 */], dir[80], genbuf[STRLEN], buf[STRLEN],only_for_b[80];
 	struct boardmem *x1;
 	struct fileheader x, x2;
 	int i, start, total;
 	changemode(READING);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	x1 = getboard(board);
 	if (x1 == 0) {
 		html_header(1);

--- a/nju09/www/bbsedit.c
+++ b/nju09/www/bbsedit.c
@@ -10,7 +10,7 @@ bbsedit_main()
 {
 	FILE *fp;
 	int type = 0, num;
-	char buf[512], path[512], file[512], board[512], title[80];
+	char buf[512], path[512], file[30], board[32], title[80];
 	int base64, isa = 0;
 	size_t len;
 	char *fn = NULL;
@@ -24,16 +24,16 @@ bbsedit_main()
 		http_fatal("匆匆过客不能修改文章，请先登录");
 	changemode(EDIT);
 	ytht_strsncpy(title, getparm("title"), 60);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	type = atoi(getparm("type"));
 	brd = getboard(board);
 	if (brd == 0)
 		http_fatal("错误的讨论区");
-	ytht_strsncpy(file, getparm("F"), 30);
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 30);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	if (!has_post_perm(&currentuser, brd))
 		http_fatal("错误的讨论区或者您无权在此讨论区发表文章");
 	if (noadm4political(board))
@@ -218,7 +218,7 @@ int
 update_form(char *board, char *file, char *title)
 {
 	FILE *fp, *fp_old;
-	char *buf = getparm("text"), path[80], path_new[80];
+	char *buf = getparm("text"), path[80], path_new[80 + 8];
 	int num = 0, filetime;
 	int usemath, useattach, nore;
 	char dir[STRLEN];

--- a/nju09/www/bbsfind.c
+++ b/nju09/www/bbsfind.c
@@ -78,7 +78,7 @@ static int search_callback(struct boardmem *board, int curr_idx, va_list ap) {
 		start = - (start + 1);
 
 	for (total = 0, j = start; j < nr; j++) {
-		if (abs(now_t - x[j].filetime) > dt)
+		if (labs(now_t - x[j].filetime) > dt)
 			continue;
 		if (id[0] != 0 && strcasecmp(x[j].owner, id))
 			continue;

--- a/nju09/www/bbsfwd.c
+++ b/nju09/www/bbsfwd.c
@@ -1,12 +1,14 @@
 #include "bbslib.h"
 
+static int do_fwd(struct fileheader *x, char *board, char *target);
+
 int
 bbsfwd_main()
 {
 	struct fileheader *x = NULL;
 	char board[80], file[80], target[80], dir[80];
 	int num;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 	check_msg();
 	ytht_strsncpy(board, getparm("B"), 32);
@@ -36,8 +38,7 @@ bbsfwd_main()
 	MMAP_END mmapfile(NULL, &mf);
 	if (x == 0)
 		http_fatal("错误的文件名");
-	printf("<center>%s -- 转寄/推荐给好友 [使用者: %s]<hr>\n", BBSNAME,
-	       currentuser.userid);
+	printf("<center>%s -- 转寄/推荐给好友 [使用者: %s]<hr>\n", BBSNAME, currentuser.userid);
 	if (target[0]) {
 		if (!strstr(target, "@")) {
 			if (!getuser(target))
@@ -53,24 +54,19 @@ bbsfwd_main()
 	printf("<form action=bbsfwd method=post>\n");
 	printf("<input type=hidden name=board value=%s>", board);
 	printf("<input type=hidden name=file value=%s>", file);
-	printf
-	    ("把文章转寄给 <input name=target size=30 maxlength=30 value=%s> (请输入对方的id或email地址). <br>\n",
-	     currentuser.email);
+	printf("把文章转寄给 <input name=target size=30 maxlength=30 value=%s> (请输入对方的id或email地址). <br>\n", currentuser.email);
 	printf("<input type=submit value=确定转寄></form>");
 	return 0;
 }
 
-int
-do_fwd(struct fileheader *x, char *board, char *target)
-{
+static int do_fwd(struct fileheader *x, char *board, char *target) {
 	char title[512], path[200];
 	sprintf(path, "boards/%s/%s", board, fh2fname(x));
 	if (!file_exist(path))
 		http_fatal("文件内容已丢失, 无法转寄");
 	sprintf(title, "[转寄] %s", x->title);
 	title[60] = 0;
-	post_mail(target, title, path, currentuser.userid, currentuser.username,
-		  fromhost, -1, 0);
+	post_mail(target, title, path, currentuser.userid, currentuser.username, fromhost, -1, 0);
 	printf("文章已转寄给'%s'<br>\n", nohtml(target));
 	printf("[<a href='javascript:history.go(-2)'>返回</a>]");
 	return 0;

--- a/nju09/www/bbsfwd.c
+++ b/nju09/www/bbsfwd.c
@@ -6,14 +6,14 @@ int
 bbsfwd_main()
 {
 	struct fileheader *x = NULL;
-	char board[80], file[80], target[80], dir[80];
+	char board[32], file[80], target[80], dir[80];
 	int num;
 	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 	check_msg();
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	ytht_strsncpy(file, getparm("F"), 30);
 	if (!file[0])
 		ytht_strsncpy(file, getparm("file"), 30);

--- a/nju09/www/bbsfwdmail.c
+++ b/nju09/www/bbsfwdmail.c
@@ -10,7 +10,7 @@ bbsfwdmail_main()
 	char bbsfwdmail_tmpfn[80];
 //	char *ptr;
 	int num;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	//struct userdata currentdata;
 	struct userec *up;
 	FILE *fp, *fp1;
@@ -25,29 +25,29 @@ bbsfwdmail_main()
 		http_fatal("匆匆过客不能进行本项操作");
 	changemode(SMAIL);
 
-    /**
-     * type of mail box
-     * 0 : in box [defualt]
-     * 1 : out box
-    */
-    int box_type = 0;
+	/**
+	* type of mail box
+	* 0 : in box [defualt]
+	* 1 : out box
+	*/
+	int box_type = 0;
 	ytht_strsncpy(buf, getparm("box_type"), 256);
-    if(buf[0] != 0) {
-        box_type = atoi(buf);
-    }
-    char type_string[20];
-    snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
+	if(buf[0] != 0) {
+		box_type = atoi(buf);
+	}
+	char type_string[20];
+	snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
 
-    if(box_type == 1) {
-        setsentmailfile(dir, currentuser.userid, ".DIR");
-    } else {
-        setmailfile(dir, currentuser.userid, ".DIR");
-    }
+	if(box_type == 1) {
+		setsentmailfile(dir, currentuser.userid, ".DIR");
+	} else {
+		setmailfile_s(dir, sizeof(dir), currentuser.userid, ".DIR");
+	}
 	if (!((currentuser.userlevel )& (PERM_CHAT|PERM_PAGE|PERM_POST)))
 		http_fatal("您没有权限发信");
 	if (HAS_PERM(PERM_DENYMAIL, currentuser))
 		http_fatal( "您已经被封禁了发信权\n");
-    //only check in-box
+	//only check in-box
 	if (box_type == 0 && check_maxmail(dir)){
 		sprintf(buff,"出错原因: 您的私人信件总大小高达 %d k,超过 %d k 时 ,您将无法使用本站的发信功能.<br>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp 请整理信件,将信件总大小控制在 %d k 内,以保证发信功能正常使用",get_mail_size(),max_mail_size()+20,max_mail_size());
 		http_fatal(buff);
@@ -66,8 +66,7 @@ bbsfwdmail_main()
 	MMAP_END mmapfile(NULL, &mf);
 	if (x == 0)
 		http_fatal("错误的信件名");
-	printf("<center>%s -- 转寄文章 [使用者: %s]<hr>\n", BBSNAME,
-	       currentuser.userid);
+	printf("<center>%s -- 转寄文章 [使用者: %s]<hr>\n", BBSNAME, currentuser.userid);
 
 	if (target[0]) {
 		if (!strstr(target, "@")) {
@@ -75,13 +74,12 @@ bbsfwdmail_main()
 				http_fatal("错误的使用者帐号");
 			strcpy(target, getuser(target)->userid);
 		}
-		snprintf(bbsfwdmail_tmpfn, 80, "bbstmpfs/tmp/bbsfwdmail.%s.%d",
-			 currentuser.userid, thispid);
-        if(box_type == 1) {
-            setsentmailfile(path, currentuser.userid, fh2fname(x));
-        } else {
-            setmailfile(path, currentuser.userid, fh2fname(x));
-        }
+		snprintf(bbsfwdmail_tmpfn, 80, "bbstmpfs/tmp/bbsfwdmail.%s.%d", currentuser.userid, thispid);
+		if(box_type == 1) {
+			setsentmailfile(path, currentuser.userid, fh2fname(x));
+		} else {
+			setmailfile_s(path, sizeof(path), currentuser.userid, fh2fname(x));
+		}
 		fp = fopen(bbsfwdmail_tmpfn, "w");
 		fp1 = fopen(path, "r");
 		if (!fp || !fp1) {
@@ -89,12 +87,10 @@ bbsfwdmail_main()
 				fclose(fp);
 			if(fp1)
 				fclose(fp1);
-			http_fatal
-			    ("信件内容已丢失，或由于其他内部错误导致转寄失败");
+			http_fatal("信件内容已丢失，或由于其他内部错误导致转寄失败");
 		}
 		if (fgets(buf, 256, fp1) != 0) {
-			if (!strncmp(buf, "发信人: ", 8)
-			    || !strncmp(buf, "寄信人: ", 8)) {
+			if (!strncmp(buf, "发信人: ", 8) || !strncmp(buf, "寄信人: ", 8)) {
 				for (i = 0; i < 6; i++) {
 					if (fgets(buf, 256, fp1) == 0)
 						break;
@@ -132,9 +128,7 @@ bbsfwdmail_main()
 	printf("信件出处: %s 的信箱<br>\n", currentuser.userid);
 	printf("<form action=bbsfwdmail?%s method=post>\n", type_string);
 	printf("<input type=hidden name=file value=%s>", file);
-	printf
-	    ("把文章转寄给 <input name=target size=30 maxlength=30 value='%s'> (请输入对方的id或email地址). <br>\n",
-	     currentuser.email);
+	printf("把文章转寄给 <input name=target size=30 maxlength=30 value='%s'> (请输入对方的id或email地址). <br>\n", currentuser.email);
 	printf("<input type=submit value=确定转寄></form>");
 	return 0;
 }
@@ -145,8 +139,7 @@ static int do_fwdmail(char *fn, struct fileheader *x, char *target) {
 		http_fatal("信件内容已丢失, 无法转寄");
 	sprintf(title, "[转寄] %s", x->title);
 	title[60] = 0;
-	post_mail(target, title, fn, currentuser.userid,
-		  currentuser.username, fromhost, -1, 0);
+	post_mail(target, title, fn, currentuser.userid, currentuser.username, fromhost, -1, 0);
 	printf("文章已转寄给'%s'<br>\n", nohtml(target));
 	printf("[<a href='javascript:history.go(-2)'>返回</a>]");
 	return 0;

--- a/nju09/www/bbsgcon.c
+++ b/nju09/www/bbsgcon.c
@@ -1,4 +1,7 @@
 #include "bbslib.h"
+
+extern int showbinaryattach(char *filename);
+
 int
 bbsgcon_main()
 {
@@ -7,7 +10,7 @@ bbsgcon_main()
 	struct fileheader x;
 	int num, total = 0;
 	struct fileheader *dirinfo = NULL;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	changemode(READING);
 	ytht_strsncpy(board, getparm("B"), 32);
 	if (!board[0])
@@ -56,22 +59,19 @@ bbsgcon_main()
 	if (num > 0) {
 		fseek(fp, sizeof (x) * (num - 1), SEEK_SET);
 		fread(&x, sizeof (x), 1, fp);
-		printf("[<a href=bbsgcon?board=%s&file=%s&num=%d>上一篇</a>]",
-		       board, fh2fname(&x), num - 1);
+		printf("[<a href=bbsgcon?board=%s&file=%s&num=%d>上一篇</a>]", board, fh2fname(&x), num - 1);
 	}
 	printf("[<a href=%s%s>本讨论区</a>]", showByDefMode(), board);
 	if (num < total - 1) {
 		fseek(fp, sizeof (x) * (num + 1), SEEK_SET);
 		fread(&x, sizeof (x), 1, fp);
-		printf("[<a href=bbsgcon?board=%s&file=%s&num=%d>下一篇</a>]",
-		       board, fh2fname(&x), num + 1);
+		printf("[<a href=bbsgcon?board=%s&file=%s&num=%d>下一篇</a>]", board, fh2fname(&x), num + 1);
 	}
 	fclose(fp);
 	ptr = dirinfo->title;
 	if (!strncmp(ptr, "Re: ", 4))
 		ptr += 4;
-	printf("[<a href='bbstfind?board=%s&th=%ld'>同主题阅读</a>]\n",
-	       board, dirinfo->thread);
+	printf("[<a href='bbstfind?board=%s&th=%ld'>同主题阅读</a>]\n", board, dirinfo->thread);
 	printf("</center></body>\n");
 	http_quit();
 	return 0;

--- a/nju09/www/bbsgcon.c
+++ b/nju09/www/bbsgcon.c
@@ -6,18 +6,18 @@ int
 bbsgcon_main()
 {
 	FILE *fp;
-	char board[80], dir[80], file[80], filename[80], *ptr;
+	char board[32], dir[80], file[32], filename[80], *ptr;
 	struct fileheader x;
 	int num, total = 0;
 	struct fileheader *dirinfo = NULL;
 	struct mmapfile mf = { .ptr = NULL };
 	changemode(READING);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
-	ytht_strsncpy(file, getparm("F"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 32);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	num = atoi(getparm("num"));
 	if (getboard(board) == NULL)
 		http_fatal("´íÎóµÄÌÖÂÛÇø");

--- a/nju09/www/bbsgdoc.c
+++ b/nju09/www/bbsgdoc.c
@@ -1,5 +1,9 @@
 #include "bbslib.h"
 
+extern void nosuchboard(char *board, char *cginame);
+extern void printboardtop(struct boardmem *x, int num);
+extern int getdocstart(int total, int lines);
+
 int
 bbsgdoc_main()
 {	//modity by macintosh 050516 for new www
@@ -56,8 +60,7 @@ bbsgdoc_main()
 
 /*	printhr();
 	printf("<table border=0>\n");
-	printf
-	    ("<tr><td>序号</td><td>状态</td><td>作者</td><td>日期</td><td>标题</td><td>星级</td><td>评价</td></tr>\n");
+	printf("<tr><td>序号</td><td>状态</td><td>作者</td><td>日期</td><td>标题</td><td>星级</td><td>评价</td></tr>\n");
 */
 	printf("%s", "<tr><td width=40 class=\"level1\">&nbsp;</td>\n"
 		"<td class=\"level1\"><TABLE width=\"95%\" cellpadding=2 cellspacing=0>\n"
@@ -82,7 +85,7 @@ bbsgdoc_main()
 	}
 	printf("</TR> </TBODY></TABLE></td></tr>\n");
 /*	printhr();
-  	printf("文章数[%d] ", total);
+	printf("文章数[%d] ", total);
 	printf("<a href=bbspst?board=%s>发表文章</a> ", board);
 	bbsdoc_helper(buf, start, total, w_info->t_lines);
 */

--- a/nju09/www/bbsincon.c
+++ b/nju09/www/bbsincon.c
@@ -2,13 +2,15 @@
 #include "check_server.h"
 int quote_quote = 0;
 
+extern int fshowcon(FILE * output, char *filename, int show_iframe);
+
 int
 bbsincon_main()
 {	//modify by macintosh 050619 for Tex Math Equ
 	char *path_info;
 	char *name, filename[128], dir[128],*ptr;
 	struct fileheader *dirinfo;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	extern char *cginame;
 	int old_quote_quote;
 	int num = -1;
@@ -31,7 +33,7 @@ bbsincon_main()
 		withinMath = 0;
 	} else {
 		usingMath = 0;
-	}   
+	}
 	if (hideboard(path_info))
 		http_fatal("错误的文件名3");
 	if (strncmp(name, "M.", 2) && strncmp(name, "G.", 2))

--- a/nju09/www/bbsinfo.c
+++ b/nju09/www/bbsinfo.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static int check_info();
+
 int
 bbsinfo_main()
 {	//modify by mintbaggio 20040829 for new www
@@ -18,53 +20,36 @@ bbsinfo_main()
 	}
 	printf("<form action=bbsinfo?type=1 method=post>");
 	printf("您的帐号: %s<br>\n", currentuser.userid);
-	printf
-	    ("您的昵称: <input type=text name=nick value='%s' size=24 maxlength=30><br>\n",
-	     currentuser.username);
+	printf("您的昵称: <input type=text name=nick value='%s' size=24 maxlength=30><br>\n", currentuser.username);
 	printf("发表大作: %d 篇<br>\n", currentuser.numposts);
 //      printf("信件数量: %d 封<br>\n", currentuser.nummails);
 	printf("上站次数: %d 次<br>\n", currentuser.numlogins);
 	printf("上站时间: %ld 分钟<br>\n", currentuser.stay / 60);
-	printf
-	    ("真实姓名: <input type=text name=realname value='%s' size=16 maxlength=16><br>\n",
-	     currentuser.realname);
-	printf
-	    ("居住地址: <input type=text name=address value='%s' size=40 maxlength=40><br>\n",
-	     currentuser.address);
+	printf("真实姓名: <input type=text name=realname value='%s' size=16 maxlength=16><br>\n", currentuser.realname);
+	printf("居住地址: <input type=text name=address value='%s' size=40 maxlength=40><br>\n", currentuser.address);
 	printf("帐号建立: %s<br>", ytht_ctime(currentuser.firstlogin));
 	printf("最近光临: %s<br>", ytht_ctime(currentuser.lastlogin));
 	printf("来源地址: %s<br>", currentuser.lasthost);
-#ifndef POP_CHECK	
-	printf
-	    ("电子邮件: <input type=text name=email value='%s' size=32 maxlength=32><br>\n",
-	     currentuser.email);
+#ifndef POP_CHECK
+	printf("电子邮件: <input type=text name=email value='%s' size=32 maxlength=32><br>\n", currentuser.email);
 #endif
 
 #if 0
-	printf
-	    ("出生日期: <input type=text name=year value=%d size=4 maxlength=4>年",
-	     currentuser.birthyear + 1900);
-	printf("<input type=text name=month value=%d size=2 maxlength=2>月",
-	       currentuser.birthmonth);
-	printf("<input type=text name=day value=%d size=2 maxlength=2>日<br>\n",
-	       currentuser.birthday);
+	printf("出生日期: <input type=text name=year value=%d size=4 maxlength=4>年", currentuser.birthyear + 1900);
+	printf("<input type=text name=month value=%d size=2 maxlength=2>月", currentuser.birthmonth);
+	printf("<input type=text name=day value=%d size=2 maxlength=2>日<br>\n", currentuser.birthday);
 	printf("用户性别: ");
-	printf("男<input type=radio value=M name=gender %s>",
-	       currentuser.gender == 'M' ? "checked" : "");
-	printf("女<input type=radio value=F name=gender %s><br>",
-	       currentuser.gender == 'F' ? "checked" : "");
+	printf("男<input type=radio value=M name=gender %s>", currentuser.gender == 'M' ? "checked" : "");
+	printf("女<input type=radio value=F name=gender %s><br>", currentuser.gender == 'F' ? "checked" : "");
 #endif
-	printf
-	    ("<input type=submit value=确定> <input type=reset value=复原>\n");
+	printf("<input type=submit value=确定> <input type=reset value=复原>\n");
 	printf("</form>");
 	printf("<hr>");
 	printf("</body></html>");
 	return 0;
 }
 
-int
-check_info()
-{
+static int check_info() {
 	size_t m;
 	char buf[256];
 	ytht_strsncpy(buf, getparm("nick"), 30);

--- a/nju09/www/bbsleft.c
+++ b/nju09/www/bbsleft.c
@@ -65,13 +65,13 @@ bbsleft_main()
 	printf("<table width=100%% border=0 cellpadding=0 cellspacing=1>\n<tr><td><div align=center>\n");
 	if (!loginok || isguest) {
 		printf("<form action=bbslogin method=post target=_top name=loginform><tr><td>\n"
-			 "<div style=\"text-align:center\">ÓÃ»§µÇÂ¼</div>\n"
-			 "ÕÊºÅ<input type=text name=id maxlength=12 size=8 class=inputuser><br>\n"
-			 "ÃÜÂë<input type=password name=pw maxlength=12 size=8 class=inputpwd><br>\n"
-			 "<input type=submit class=sumbitshort value=µÇÂ¼>&nbsp;"
-			 "<input type=submit class=resetshort value=×¢²á onclick=\"{openreg();return false}\">"
-			 "&nbsp&nbsp<a target=f3 href='bbsfindpass' target='_blank' class=linkindex><br>ÕÒ»ØÕÊºÅ»òÃÜÂë</a><br>\n"
-			 "</form>\n");
+			"<div style=\"text-align:center\">ÓÃ»§µÇÂ¼</div>\n"
+			"ÕÊºÅ<input type=text name=id maxlength=12 size=8 class=inputuser><br>\n"
+			"ÃÜÂë<input type=password name=pw maxlength=12 size=8 class=inputpwd><br>\n"
+			"<input type=submit class=sumbitshort value=µÇÂ¼>&nbsp;"
+			"<input type=submit class=resetshort value=×¢²á onclick=\"{openreg();return false}\">"
+			"&nbsp&nbsp<a target=f3 href='bbsfindpass' target='_blank' class=linkindex><br>ÕÒ»ØÕÊºÅ»òÃÜÂë</a><br>\n"
+			"</form>\n");
 	} else {
 		char buf[256] = "Î´×¢²áÓÃ»§";
 		printf("<a class=1100>ÓÃ»§: <a href=bbsqry?userid=%s target=f3>%s</a><br>",
@@ -186,7 +186,7 @@ bbsleft_main()
 			"size=9 onclick=\"this.select()\" value=Ñ¡ÔñÌÖÂÛÇø><input type=submit class=sumbitgrey value=go></td></form></tr>\n");
 			if (loginok && !isguest && !(currentuser.userlevel & PERM_LOGINOK) && !has_fill_form())
 			printf("<tr><td align=right> <img src=\"/images/list2.gif\"></td>\n"
-			 "<td><a class=linkleft href=\"bbsform\" target=f3>ÌîĞ´×¢²áµ¥</a></td></tr>\n");
+					"<td><a class=linkleft href=\"bbsform\" target=f3>ÌîĞ´×¢²áµ¥</a></td></tr>\n");
 		if (loginok && !isguest && HAS_PERM(PERM_SYSOP, currentuser))        //add by mintbaggio@BMY for www SYSOP kick www user
 			printf("<tr><td align=right> <img src=\"/images/list2.gif\"></td>\n"
 					"<td><a class=linkleft href=\"kick\" target=f3>ÌßwwwÏÂÕ¾</a></td></tr>\n");
@@ -252,9 +252,9 @@ endleft:
 			printf("<script>setTimeout('open(\"regreq\", \"winREGREQ\", \"width=600,height=460\")', 1800000);</script>");
 		if (loginok && !isguest) {
 			char filename[80];
-			sethomepath(filename, currentuser.userid);
+			sethomepath_s(filename, sizeof(filename), currentuser.userid);
 			mkdir(filename, 0755);
-			sethomefile(filename, currentuser.userid, BADLOGINFILE);
+			sethomefile_s(filename, sizeof(filename), currentuser.userid, BADLOGINFILE);
 			if (file_exist(filename)) {
 				printf("<script>"
 						"window.open('bbsbadlogins', 'badlogins', 'toolbar=0, scrollbars=1, location=0, statusbar=1, menubar=0, resizable=1, width=450, height=300');"

--- a/nju09/www/bbsmail.c
+++ b/nju09/www/bbsmail.c
@@ -1,34 +1,34 @@
 #include "bbslib.h"
 
+extern int getdocstart(int total, int lines);
+
 int
 bbsmail_main()
 {	//modify by mintbaggio 20040829 for new www
 	FILE *fp;
 	int i, start, total;
 	char buf[512], dir[80];
-    /**
-     * a string like "type=1"
-     */
-    char type_string[20];
+	/** a string like "type=1" */
+	char type_string[20];
 	struct fileheader x;
-    /**
-     * type of mail box
-     * 0 : in box [defualt]
-     * 1 : out box
-     */
-    int box_type = 0; 
+	/**
+	* type of mail box
+	* 0 : in box [defualt]
+	* 1 : out box
+	*/
+	int box_type = 0;
 	if (!loginok || isguest)
 		http_fatal("您尚未登录, 请先登录");
 	ytht_strsncpy(buf, getparm("box_type"), 10);
-    if(buf[0] != 0) {
-        box_type = atoi(buf);
-    }
-    snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
-    if(box_type == 1) {
-        setsentmailfile(dir, currentuser.userid, ".DIR");
-    } else {
-        setmailfile(dir, currentuser.userid, ".DIR");
-    }
+	if(buf[0] != 0) {
+		box_type = atoi(buf);
+	}
+	snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
+	if(box_type == 1) {
+		setsentmailfile(dir, currentuser.userid, ".DIR");
+	} else {
+		setmailfile_s(dir, sizeof(dir), currentuser.userid, ".DIR");
+	}
 	if(cache_header(file_time(dir),10))
 		return 0;
 	html_header(1);
@@ -56,20 +56,20 @@ bbsmail_main()
 		"<table width=100%% height=100%% border=0 cellpadding=0 cellspacing=0 class=level2>\n"
 		"<tr>\n<td width=40 rowspan=2>&nbsp; </td>\n"
 		);
-    const char *name_of_box;
-    if(box_type == 1) {
-        name_of_box = "已发信件";
-    } else {
-        name_of_box = "信件列表";
-    }
+	const char *name_of_box;
+	if(box_type == 1) {
+		name_of_box = "已发信件";
+	} else {
+		name_of_box = "信件列表";
+	}
 
 	printf("<td height=35>%s &gt;  <span id=topmenu_b>%s</span> [使用者: <span class=themetext>%s</span>] &#187; <b>信箱容量:</b> <span class=smalltext>%dk</span> &#187; <b>已用空间</b><spanclass=smalltext>%dk</span></td></tr>\n", BBSNAME, name_of_box, currentuser.userid,max_mail_size(),get_mail_size());
 	printf("%s", "<tr>\n"
 		"<td height=35 valign=top><a href='javascript:SelectAll()' class=\"btnsubmittheme\">全部选中</a>\n"
 		"<a onclick='return confirm(\"你真的要删除这些信件吗?\")' href='javascript:document.maillist.submit()' class=\"btnsubmittheme\">删除选中的邮件</a>\n");
-    if(box_type == 0) {
+	if(box_type == 0) {
 		printf("<a href='bbspstmail' class=\"btnsubmittheme\" title=\"发送信件 accesskey: m\" accesskey=\"m\">发送信件</a>\n");
-    }
+	}
 	total = file_size(dir) / sizeof (struct fileheader);
 	if (total < 0 || total > 30000)
 		http_fatal("too many mails");
@@ -82,15 +82,15 @@ bbsmail_main()
 
 	if (total > w_info->t_lines)
 		printf("<a href='mail?S=1&%s' class=btnsubmittheme>第一页</a>\n"
-			"<a href='mail?S=0&%s' class=btnsubmittheme>最后一页</a>\n",
-                type_string, type_string);
+				"<a href='mail?S=0&%s' class=btnsubmittheme>最后一页</a>\n",
+				type_string, type_string);
 	//printf("start=%d, t_line=%d\n", start, w_info->t_lines);
 	if(start > w_info->t_lines+1)
 		printf("<a href='bbsmail?&S=%d&%s' class=btnsubmittheme>上一页</a>\n", start - w_info->t_lines ,type_string);
 	if (start < total - w_info->t_lines + 1)
 		printf("<a href='bbsmail?&S=%d&%s' class=btnsubmittheme>下一页</a>\n", start + w_info->t_lines, type_string);
 	printf("<a href=# onclick='javascript:{location=location;return false;}' class=btnsubmittheme>刷新</a>\n");
-	
+
 	printf("</td>\n</tr>\n");
 #if 0
 	total = file_size(dir) / sizeof (struct fileheader);
@@ -112,9 +112,8 @@ bbsmail_main()
 		);
 
 	printf("<table width=95%% cellpadding=2 cellspacing=0><form action=bbsdelmail?%s name=maillist>\n", type_string);
-    printf("<input type=\"hidden\" name=\"box_type\" value=\"%d\"></input>\n", box_type);
-	printf
-	    ("%s","<tbody><tr>\n"
+	printf("<input type=\"hidden\" name=\"box_type\" value=\"%d\"></input>\n", box_type);
+	printf("%s","<tbody><tr>\n"
 		"<td class=tdtitle>选择</td>\n"
 		"<td class=tdtitle>序号</td>\n"
 		"<td class=tdtitle>状态</td>\n"
@@ -126,19 +125,16 @@ bbsmail_main()
 		int type = 'N';
 		if (fread(&x, sizeof (x), 1, fp) <= 0)
 			break;
-		printf("<tr><td class=tdborder><input type=checkbox name=F%d value=%s></td>",
-		       i, fh2fname(&x));
+		printf("<tr><td class=tdborder><input type=checkbox name=F%d value=%s></td>", i, fh2fname(&x));
 		printf("<td class=tdborder>%d</td>", i + start);
 		if (x.accessed & FH_READ)
 			type = ' ';
 		if (x.accessed & FH_MARKED)
 			type = (type == 'N') ? 'M' : 'm';
-		printf("<td class=tdborder>%c%c</td>", type,
-		       x.accessed & FH_ATTACHED ? '@' : ' ');
+		printf("<td class=tdborder>%c%c</td>", type, x.accessed & FH_ATTACHED ? '@' : ' ');
 		printf("<td class=tdborder>%s</td>", userid_str(fh2owner(&x)));
 		printf("<td class=tdborder>%12.12s</td>", ytht_ctime(x.filetime) + 4);
-		printf("<td class=tdborder><a href=bbsmailcon?file=%s&num=%d&%s>", fh2fname(&x),
-		       i + start - 1, type_string);
+		printf("<td class=tdborder><a href=bbsmailcon?file=%s&num=%d&%s>", fh2fname(&x), i + start - 1, type_string);
 		if (strncmp("Re: ", x.title, 4))
 			printf("★ ");
 		x.title[40] = 0;
@@ -151,19 +147,17 @@ bbsmail_main()
 #if 0
 	printf("[信件总数: %d] ", total);
 	printf("[<a href='javascript:SelectAll()'>全部选中</a>] ");
-	printf
-	    ("[<a onclick='return confirm(\"你真的要删除这些信件吗?\")'"
-	     " href='javascript:document.maillist.submit()'>删除选中的邮件</a>] ");
+	printf("[<a onclick='return confirm(\"你真的要删除这些信件吗?\")'"
+			" href='javascript:document.maillist.submit()'>删除选中的邮件</a>] ");
 	printf("[<a href=bbspstmail>发送信件</a>] ");
 	if (total > w_info->t_lines)
 		printf("<a href=mail?S=1%s>第一页</a> <a href=mail?S=0%s>最后一页</a> ", type_string, type_string);
 	bbsdoc_helper("bbsmail?", start, total, w_info->t_lines);
-	printf
-	    ("<form><input type=submit value=跳转到> 第 <input style='height:20px' type=text name=start size=3> 封</form></body>");
+	printf("<form><input type=submit value=跳转到> 第 <input style='height:20px' type=text name=start size=3> 封</form></body>");
 #endif
 	printf("<form><input action=bbsmail?%s type=submit class=resetlong value=跳转到> 第 <input type=text name=start size=3> 封\n", type_string);
-    printf("<input type=\"hidden\" name=\"box_type\" value=\"%d\"></input>\n", box_type);
-    printf("</form>\n");
+	printf("<input type=\"hidden\" name=\"box_type\" value=\"%d\"></input>\n", box_type);
+	printf("</form>\n");
 
 	printf("</td></tr><table></td></tr></table></body>\n");
 	http_quit();

--- a/nju09/www/bbsmailcon.c
+++ b/nju09/www/bbsmailcon.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+extern int showbinaryattach(char *filename);
+
 int
 bbsmailcon_main()
 {	// modify by mintbaggio for new www 041227
@@ -10,19 +12,19 @@ bbsmailcon_main()
 	if ((!loginok || isguest) && (!tempuser))
 		http_fatal("请先登录%d", tempuser);
 
-    /**
-     * type of mail box
-     * 0 : in box [defualt]
-     * 1 : out box
-     */
-    int box_type = 0;
-    char buf[10];
+	/**
+	* type of mail box
+	* 0 : in box [defualt]
+	* 1 : out box
+	*/
+	int box_type = 0;
+	char buf[10];
 	ytht_strsncpy(buf, getparm("box_type"), 10);
-    if(buf[0] != 0) {
-        box_type = atoi(buf);
-    }
-    char type_string[20];
-    snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
+	if(buf[0] != 0) {
+		box_type = atoi(buf);
+	}
+	char type_string[20];
+	snprintf(type_string, sizeof(type_string), "box_type=%d", box_type);
 
 	//if (tempuser) http_fatal("user %d", tempuser);
 	changemode(RMAIL);
@@ -33,21 +35,21 @@ bbsmailcon_main()
 		http_fatal("错误的参数1");
 	if (strstr(file, "..") || strstr(file, "/"))
 		http_fatal("错误的参数2");
-    if(box_type == 1) {
-        setsentmailfile(path, id, file);
-    }else {
-        setmailfile(path, id, file);
-    }
+	if(box_type == 1) {
+		setsentmailfile(path, id, file);
+	}else {
+		setmailfile_s(path, sizeof(path), id, file);
+	}
 	if (*getparm("attachname") == '/') {
 		showbinaryattach(path);
 		return 0;
 	}
 	if (!tempuser) {
-        if(box_type == 1) {
-            setsentmailfile(dir, id, ".DIR");
-        }else {
-            setmailfile(dir, id, ".DIR");
-        }
+		if(box_type == 1) {
+			setsentmailfile(dir, id, ".DIR");
+		}else {
+			setmailfile_s(dir, sizeof(dir), id, ".DIR");
+		}
 		total = file_size(dir) / sizeof (x);
 		if (total <= 0)
 			http_fatal("错误的参数3 %s", dir);
@@ -78,10 +80,9 @@ bbsmailcon_main()
 	}
 #endif
 	if (loginok && !isguest && !(currentuser.userlevel & PERM_LOGINOK) &&
-	    !tempuser && !strncmp(x.title, "<注册失败>", 10)
-	    && !has_fill_form())
-		printf
-		    ("--&gt;<a href=bbsform><font color=RED size=+1>重新填写注册单</font></a>&lt;--\n<br>");
+			!tempuser && !strncmp(x.title, "<注册失败>", 10)
+			&& !has_fill_form())
+		printf("--&gt;<a href=bbsform><font color=RED size=+1>重新填写注册单</font></a>&lt;--\n<br>");
 #if 0
 	printf("<center>");
 	sprintf(path, "mail/%c/%s/%s", mytoupper(id[0]), id, file);
@@ -100,36 +101,30 @@ bbsmailcon_main()
 		if (num < total - 1) {
 			fseek(fp, sizeof (x) * (num + 1), SEEK_SET);
 			fread(&x, sizeof (x), 1, fp);
-			printf("<a href=bbsmailcon?file=%s&num=%d&%s class=\"btnsubmittheme\" title=\"下一篇 accesskey: n\" accesskey=\"n\">下一篇</a>",
-			       fh2fname(&x), num + 1, type_string);
+			printf("<a href=bbsmailcon?file=%s&num=%d&%s class=\"btnsubmittheme\" title=\"下一篇 accesskey: n\" accesskey=\"n\">下一篇</a>", fh2fname(&x), num + 1, type_string);
 		}
 		if (num >= 0 && num < total) {
 			fseek(fp, sizeof (x) * num, SEEK_SET);
-			if (fread(&x, sizeof (x), 1, fp) > 0
-			    && !(x.accessed & FH_READ)) {
+			if (fread(&x, sizeof (x), 1, fp) > 0 && !(x.accessed & FH_READ)) {
 				x.accessed |= FH_READ;
 				fseek(fp, sizeof (x) * num, SEEK_SET);
 				fwrite(&x, sizeof (x), 1, fp);
-				printf
-				    ("<script>top.f4.location.reload();</script>");
+				printf("<script>top.f4.location.reload();</script>");
 			}
 		}
-        //send box only support 'foward'
-        if(box_type == 0) {
-		    printf("<a href='bbspstmail?file=%s&num=%d' class=\"btnsubmittheme\" title=\"回信 accesskey: m\" accesskey=\"m\">回信</a>",
-		       fh2fname(&x), num);
-		    printf("<a href='bbscccmail?file=%s' class=\"btnsubmittheme\" title=\"转贴 accesskey: c\" accesskey=\"c\">转贴</a>",
-		       fh2fname(&x));
-        }
-		printf("<a href='bbsfwdmail?file=%s&%s' class=\"btnsubmittheme\" title=\"转寄 accesskey: u\" accesskey=\"u\">转寄</a>",
-		       fh2fname(&x), type_string);
+		//send box only support 'foward'
+		if(box_type == 0) {
+			printf("<a href='bbspstmail?file=%s&num=%d' class=\"btnsubmittheme\" title=\"回信 accesskey: m\" accesskey=\"m\">回信</a>", fh2fname(&x), num);
+			printf("<a href='bbscccmail?file=%s' class=\"btnsubmittheme\" title=\"转贴 accesskey: c\" accesskey=\"c\">转贴</a>", fh2fname(&x));
+		}
+		printf("<a href='bbsfwdmail?file=%s&%s' class=\"btnsubmittheme\" title=\"转寄 accesskey: u\" accesskey=\"u\">转寄</a>", fh2fname(&x), type_string);
 		fclose(fp);
 	}
-    if(box_type == 1) {
-        setsentmailfile(path, id, file);
-    } else {
-        setmailfile(path, id, file);
-    }
+	if(box_type == 1) {
+		setsentmailfile(path, id, file);
+	} else {
+		setmailfile_s(path, sizeof(path), id, file);
+	}
 	showcon(path);
 
 	printf("</table></td></tr></table></body>\n");

--- a/nju09/www/bbsmailmsg.c
+++ b/nju09/www/bbsmailmsg.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static void mail_msg(struct userec *user);
+
 int
 bbsmailmsg_main()
 {
@@ -16,32 +18,31 @@ bbsmailmsg_main()
 	return 0;
 }
 
-void                    
-mail_msg(struct userec *user)                                                                                                                 {
-        char fname[30];      
-        char buf[MAX_MSG_SIZE], showmsg[MAX_MSG_SIZE * 2];
-        int i;  
-        struct msghead head;
-        time_t now;
-        char title[STRLEN];
-        FILE *fn;
-        int count;
+static void mail_msg(struct userec *user) {
+	char fname[30];
+	char buf[MAX_MSG_SIZE], showmsg[MAX_MSG_SIZE * 2];
+	int i;
+	struct msghead head;
+	time_t now;
+	char title[STRLEN];
+	FILE *fn;
+	int count;
 
-        sprintf(fname, "tmp/%s.msg", user->userid);
-        fn = fopen(fname, "w");
-        count = get_msgcount(0, user->userid);
-        for (i = 0; i < count; i++) {
-                load_msghead(0, user->userid, &head, i);
-                load_msgtext(user->userid, &head, buf);
-                translate_msg(buf, &head, showmsg, 0);
-                fprintf(fn, "%s", showmsg);
-        }
-        fclose(fn);
+	sprintf(fname, "tmp/%s.msg", user->userid);
+	fn = fopen(fname, "w");
+	count = get_msgcount(0, user->userid);
+	for (i = 0; i < count; i++) {
+		load_msghead(0, user->userid, &head, i);
+		load_msgtext(user->userid, &head, buf);
+		translate_msg(buf, &head, showmsg, 0);
+		fprintf(fn, "%s", showmsg);
+	}
+	fclose(fn);
 
-        now = time(0);
-        sprintf(title, "[%12.12s] 所有讯息备份", ctime(&now) + 4);
-        mail_file(fname, user->userid, title, user->userid);
-        unlink(fname);
-        clear_msg(user->userid);
+	now = time(0);
+	sprintf(title, "[%12.12s] 所有讯息备份", ctime(&now) + 4);
+	mail_file(fname, user->userid, title, user->userid);
+	unlink(fname);
+	clear_msg(user->userid);
 }
 

--- a/nju09/www/bbsman.c
+++ b/nju09/www/bbsman.c
@@ -2,14 +2,14 @@
 #include "bmy/article.h"
 #include "bmy/board.h"
 
-static int do_del(char *board, char *file);
+//static int do_del(char *board, char *file);
 static int do_set(char *dirptr, int size, char *file, int flag, char *board);
 
 int
 bbsman_main()
 {
 	int i, total = 0, mode;
-	char board[80], tbuf[256], *cbuf;
+	char board[32], tbuf[256], *cbuf;
 	char dir[80];
 	struct boardmem *brd;
 	char *data= NULL;
@@ -20,7 +20,7 @@ bbsman_main()
 	if (!loginok || isguest)
 		http_fatal("请先登录");
 	changemode(READING);
-	ytht_strsncpy(board, getparm("board"), 60);
+	ytht_strsncpy(board, getparm("board"), sizeof(board));
 	mode = atoi(getparm("mode"));
 	brd = getboard(board);
 	if (brd == 0)
@@ -87,6 +87,7 @@ bbsman_main()
 	return 0;
 }
 
+/*
 static int do_del(char *board, char *file) {
 	FILE *fp;
 	int num = 0, filetime;
@@ -118,7 +119,7 @@ static int do_del(char *board, char *file) {
 	fclose(fp);
 	printf("<tr><td><td>%s<td>文件不存在.\n", file);
 	return -1;
-}
+}*/
 
 static int do_set(char *dirptr, int size, char *file, int flag, char *board) {
 	char path[256], buf[256];

--- a/nju09/www/bbsmdoc.c
+++ b/nju09/www/bbsmdoc.c
@@ -8,7 +8,7 @@ int
 bbsmdoc_main()
 {
 	FILE *fp;
-	char board[80], dir[80];
+	char board[32], dir[80];
 	struct boardmem *x1;
 	struct fileheader x;
 	int i, start, total;
@@ -16,9 +16,9 @@ bbsmdoc_main()
 	if (!loginok || isguest)
 		http_fatal("ÇëÏÈµÇÂ¼");
 	changemode(READING);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	x1 = getboard(board);
 	if (x1 == 0) {
 		html_header(1);

--- a/nju09/www/bbsmmdoc.c
+++ b/nju09/www/bbsmmdoc.c
@@ -8,7 +8,7 @@ int
 bbsmmdoc_main()
 {	//developed by macintosh 050519 for new www
 	FILE *fp, *fp1, *fp2;
-	char board[80], dir[80],buf[128],name[80];
+	char board[32], dir[80],buf[128],name[80];
 	struct boardmem *x1;
 	struct fileheader x;
 	int i, start, total=0;
@@ -16,7 +16,7 @@ bbsmmdoc_main()
 	check_msg();
 	printf("<script src=/function.js></script>\n");
 	changemode(READING);
-	ytht_strsncpy(board, getparm2("B", "board"), 32);
+	ytht_strsncpy(board, getparm2("B", "board"), sizeof(board));
 	x1 = getboard(board);
 	if (x1 == 0)
 		nosuchboard(board, "bbsmmdoc");

--- a/nju09/www/bbsmmdoc.c
+++ b/nju09/www/bbsmmdoc.c
@@ -1,5 +1,9 @@
 #include "bbslib.h"
 
+extern void printboardtop(struct boardmem *x, int num);
+extern int getdocstart(int total, int lines);
+extern void nosuchboard(char *board, char *cginame);
+
 int
 bbsmmdoc_main()
 {	//developed by macintosh 050519 for new www
@@ -37,8 +41,8 @@ bbsmmdoc_main()
 	}
 	fclose(fp1);
 	fclose(fp2);
-	
-	fp = fopen(buf, "r");	
+
+	fp = fopen(buf, "r");
 	start = getdocstart(total, w_info->t_lines);
 	printf("<body topmargin=0 leftmargin=0>\n");
 	printf("<table width=\"100%%\" border=0 cellpadding=0 cellspacing=0>\n"
@@ -51,7 +55,7 @@ bbsmmdoc_main()
 	printf("<td align=right><a href=\"mmdoc?B=%s&S=%d\" title=\"第一页 accesskey: 1\" accesskey=\"1\">第一页</a>\n", board, 1);
 	if(start > w_info->t_lines+1) printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"上一页 accesskey: f\" accesskey=\"f\">上一页</a>\n", board, (start-w_info->t_lines));
 	if(start < total-w_info->t_lines+1) printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"下一页 accesskey: n\" accesskey=\"n\">下一页</a>\n", board, (start+w_info->t_lines));
-	printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"最后一页 accesskey: l\" accesskey=\"l\">最后一页</a>\n", board, (total-w_info->t_lines+1)); 
+	printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"最后一页 accesskey: l\" accesskey=\"l\">最后一页</a>\n", board, (total-w_info->t_lines+1));
 	printf("<input type=hidden name=B value=%s>", board);
 	printf("<input name=Submit1 type=Submit class=sumbitgrey value=Go>\n"
 		"<input name=S type=text style=\"font-size:11px;font-family:verdana;\" size=4></td>\n"
@@ -74,23 +78,18 @@ bbsmmdoc_main()
 		"<TD class=tdtitle>星级</TD>\n"
 		"<TD class=tdtitle>评价</TD>\n"
 		"</TR>\n");
-	
+
 	fseek(fp, (start - 1) * sizeof (struct fileheader), SEEK_SET);
 	for (i = 0; i < w_info->t_lines; i++) {
 		if (fread(&x, sizeof (x), 1, fp) <= 0)
 			break;
 		printf("<tr><td class=tdborder>%d</td><td class=tdborder> </td><td class=tduser>%s</td>",
-		       start + i, 
-		       //flag_str(x.accessed) , 
-		       userid_str(x.owner));
+				start + i,
+				//flag_str(x.accessed) ,
+				userid_str(x.owner));
 		printf("<td align=center class=tdborder>%12.12s</td>", ytht_ctime(x.filetime) + 4);
-		printf
-		    ("<td class=tdborder><a href=con?B=%s&F=%s>%s%s</a></td><td class=tdborder>%d</td><td class=tdborder>%d人</td></tr>\n",
-		     board, fh2fname(&x),  strncmp(x.title,
-								 "Re: ",
-								 4) ? "● " :
-		     "", void1(titlestr(x.title)), x.staravg50 / 50,
-		     x.hasvoted);
+		printf("<td class=tdborder><a href=con?B=%s&F=%s>%s%s</a></td><td class=tdborder>%d</td><td class=tdborder>%d人</td></tr>\n",
+				board, fh2fname(&x),  strncmp(x.title, "Re: ", 4) ? "● " : "", void1(titlestr(x.title)), x.staravg50 / 50, x.hasvoted);
 	}
 	printf("</TR> </TBODY></TABLE></td></tr>\n");
 	printf("<tr><td height=40 class=\"level1\">&nbsp;</td>\n"
@@ -103,7 +102,7 @@ bbsmmdoc_main()
 	printf("<td align=right><a href=\"mmdoc?B=%s&S=%d\" title=\"第一页 accesskey: 1\" accesskey=\"1\">第一页</a>\n", board, 1);
 	if(start > w_info->t_lines+1) printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"上一页 accesskey: f\" accesskey=\"f\">上一页</a>\n", board, (start-w_info->t_lines));
 	if(start < total-w_info->t_lines+1) printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"下一页 accesskey: n\" accesskey=\"n\">下一页</a>\n", board, (start+w_info->t_lines));
-	printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"最后一页 accesskey: l\" accesskey=\"l\">最后一页</a>\n", board, (total-w_info->t_lines+1)); 
+	printf("<a href=\"mmdoc?B=%s&S=%d\" title=\"最后一页 accesskey: l\" accesskey=\"l\">最后一页</a>\n", board, (total-w_info->t_lines+1));
 	printf("<input type=hidden name=B value=%s>", board);
 	printf("<input name=Submit2 type=Submit class=sumbitgrey value=Go>\n"
 		"<input name=S type=text style=\"font-size:11px;font-family:verdana;\" size=4></td>\n"

--- a/nju09/www/bbsmnote.c
+++ b/nju09/www/bbsmnote.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static void save_note(char *path);
+
 int
 bbsmnote_main()
 {
@@ -7,7 +9,7 @@ bbsmnote_main()
 	char *ptr, path[256], buf[10000], board[256], notestr[40], buf2[128];
 	struct boardmem *x;
 	int mode;
-	
+
 	html_header(1);
 	check_msg();
 	printf("<center>\n");
@@ -42,9 +44,7 @@ bbsmnote_main()
 		save_note(path);
 	}
 	printf("%s -- ±à¼­%s [ÌÖÂÛÇø: %s]<hr>\n", BBSNAME, notestr, board);
-	printf
-	    ("<form name=form1 method=post action=bbsmnote?type=update&board=%s&mode=%d>\n",
-	     board, mode);
+	printf("<form name=form1 method=post action=bbsmnote?type=update&board=%s&mode=%d>\n", board, mode);
 	fp = fopen(path, "r");
 	if (fp) {
 		fread(buf, 9999, 1, fp);
@@ -54,8 +54,7 @@ bbsmnote_main()
 		fclose(fp);
 	}
 	printf("<table border=1><tr><td>");
-	printf
-	    ("<textarea  onkeydown='if(event.keyCode==87 && event.ctrlKey) {document.form1.submit(); return false;}'  onkeypress='if(event.keyCode==10) return document.form1.submit()' name=text rows=20 cols=80 wrap=virtual>\n");
+	printf("<textarea  onkeydown='if(event.keyCode==87 && event.ctrlKey) {document.form1.submit(); return false;}'  onkeypress='if(event.keyCode==10) return document.form1.submit()' name=text rows=20 cols=80 wrap=virtual>\n");
 	printf("%s", nohtml(void1(buf)));
 	printf("</textarea></table>\n");
 	printf("<input type=submit value=´æÅÌ> ");
@@ -65,9 +64,7 @@ bbsmnote_main()
 	return 0;
 }
 
-void
-save_note(char *path)
-{
+static void save_note(char *path) {
 	FILE *fp;
 	char buf[10000];
 	fp = fopen(path, "w");

--- a/nju09/www/bbsmnote.c
+++ b/nju09/www/bbsmnote.c
@@ -6,7 +6,7 @@ int
 bbsmnote_main()
 {
 	FILE *fp;
-	char *ptr, path[256], buf[10000], board[256], notestr[40], buf2[128];
+	char *ptr, path[256], buf[10000], board[30], notestr[40], buf2[128];
 	struct boardmem *x;
 	int mode;
 
@@ -16,7 +16,7 @@ bbsmnote_main()
 	if (!loginok || isguest)
 		http_fatal("´Ò´Ò¹ý¿Í£¬ÇëÏÈµÇÂ¼");
 	changemode(EDIT);
-	ytht_strsncpy(board, getparm("board"), 30);
+	ytht_strsncpy(board, getparm("board"), sizeof(board));
 	x = getboard(board);
 	mode = atoi(getparm("mode"));
 	if (!has_BM_perm(&currentuser, x))

--- a/nju09/www/bbsmywww.c
+++ b/nju09/www/bbsmywww.c
@@ -1,25 +1,23 @@
 #include "bbslib.h"
 
+static int save_set(int t_lines, int link_mode, int def_mode, int att_mode, int doc_mode);
+
 int
 bbsmywww_main()
 {	//modify by mintbaggio 20040829 for new www
 	char *ptr, buf[256];
-	int t_lines = 20, link_mode = 0, def_mode = 0, att_mode = 0, doc_mode =
-	    0, type;
+	int t_lines = 20, link_mode = 0, def_mode = 0, att_mode = 0, doc_mode = 0, type;
 	html_header(1);
 	check_msg();
 	printf("<body>");
 	if (!loginok || isguest)
 		http_fatal("匆匆过客不能定制界面");
 	changemode(GMENU);
-	if (readuservalue(currentuser.userid, "t_lines", buf, sizeof (buf)) >=
-	    0)
+	if (readuservalue(currentuser.userid, "t_lines", buf, sizeof (buf)) >= 0)
 		t_lines = atoi(buf);
-	if (readuservalue(currentuser.userid, "link_mode", buf, sizeof (buf)) >=
-	    0)
+	if (readuservalue(currentuser.userid, "link_mode", buf, sizeof (buf)) >= 0)
 		link_mode = atoi(buf);
-	if (readuservalue(currentuser.userid, "def_mode", buf, sizeof (buf)) >=
-	    0)
+	if (readuservalue(currentuser.userid, "def_mode", buf, sizeof (buf)) >= 0)
 		def_mode = atoi(buf);
 //      if (readuservalue(currentuser.userid, "att_mode", buf, sizeof(buf)) >= 0) att_mode=atoi(buf);
 	att_mode = w_info->att_mode;
@@ -40,8 +38,7 @@ bbsmywww_main()
 	ptr = getparm("doc_mode");
 	if (ptr[0])
 		doc_mode = atoi(ptr);
-	printf("<center><div class=rhead>%s -- WWW个人定制 [使用者: <span class=h11>%s</span>]</div><hr>", BBSNAME,
-	       currentuser.userid);
+	printf("<center><div class=rhead>%s -- WWW个人定制 [使用者: <span class=h11>%s</span>]</div><hr>", BBSNAME, currentuser.userid);
 //      if (type > 0)
 //              return save_set(t_lines, link_mode, def_mode, att_mode);
 	if (t_lines < 10 || t_lines > 40)
@@ -59,36 +56,20 @@ bbsmywww_main()
 	printf("<table><form action=bbsmywww>\n");
 	printf("<tr><td>\n");
 	printf("<input type=hidden name=type value=1>");
-	printf
-	    ("一屏显示的文章行数(10-40): <input name=t_lines size=8 value=%d><br>\n",
-	     t_lines);
-	printf
-	    ("链接识别 (0识别, 1不识别): <input name=link_mode size=8 value=%d><br>\n",
-	     link_mode);
-	printf
-	    ("缺省模式 (0一般, 1主题): &nbsp;&nbsp;<input name=def_mode size=8 value=%d><br>\n",
-	     def_mode);
-	printf
-	    ("<font color=red>need refresh after changed.</font><br>\n");
-	printf
-	    ("附件模式 (0普通，1特殊): &nbsp;&nbsp;<input name=att_mode size=8 value=%d><br><br>\n",
-	     att_mode);
-	printf
-	    ("<font color=red>附件模式设置为 0 可能速度比较快。图片显示有问题者可以将附件模式设置为 1。</font><br>\n");
-	printf
-	    ("文章模式 (0普通，1特殊): &nbsp;&nbsp;<input name=doc_mode size=8 value=%d><br><br>\n",
-	     doc_mode);
-	printf
-	    ("<font color=red>文章模式设置为 0 可能速度比较快。文章显示有问题者可以将文章模式设置为 1。</font><br>\n");
-	printf
-	    ("</td></tr><tr><td align=center><input type=submit value=确定> <input type=reset value=复原>\n");
+	printf("一屏显示的文章行数(10-40): <input name=t_lines size=8 value=%d><br>\n", t_lines);
+	printf("链接识别 (0识别, 1不识别): <input name=link_mode size=8 value=%d><br>\n", link_mode);
+	printf("缺省模式 (0一般, 1主题): &nbsp;&nbsp;<input name=def_mode size=8 value=%d><br>\n", def_mode);
+	printf("<font color=red>need refresh after changed.</font><br>\n");
+	printf("附件模式 (0普通，1特殊): &nbsp;&nbsp;<input name=att_mode size=8 value=%d><br><br>\n", att_mode);
+	printf("<font color=red>附件模式设置为 0 可能速度比较快。图片显示有问题者可以将附件模式设置为 1。</font><br>\n");
+	printf("文章模式 (0普通，1特殊): &nbsp;&nbsp;<input name=doc_mode size=8 value=%d><br><br>\n", doc_mode);
+	printf("<font color=red>文章模式设置为 0 可能速度比较快。文章显示有问题者可以将文章模式设置为 1。</font><br>\n");
+	printf("</td></tr><tr><td align=center><input type=submit value=确定> <input type=reset value=复原>\n");
 	printf("</td></tr></form></table></body></html>\n");
 	return 0;
 }
 
-int
-save_set(int t_lines, int link_mode, int def_mode, int att_mode, int doc_mode)
-{
+static int save_set(int t_lines, int link_mode, int def_mode, int att_mode, int doc_mode) {
 	char buf[20];
 	if (t_lines < 10 || t_lines > 40)
 		http_fatal("错误的行数");

--- a/nju09/www/bbsparm.c
+++ b/nju09/www/bbsparm.c
@@ -1,5 +1,7 @@
 #include "bbslib.h"
 
+static int read_form();
+
 char *defines[] = {
 	"呼叫器关闭时可让好友呼叫",	/* DEF_FRIENDCALL */
 	"接受所有人的讯息",	/* DEF_ALLMSG */
@@ -71,9 +73,7 @@ bbsparm_main()
 	return 0;
 }
 
-int
-read_form()
-{
+static int read_form() {
 	int i, perm = 1, def = 0;
 	char var[100];
 	for (i = 0; i < 32; i++) {

--- a/nju09/www/bbsparm.c
+++ b/nju09/www/bbsparm.c
@@ -2,7 +2,7 @@
 
 static int read_form();
 
-char *defines[] = {
+static const char *defines[] = {
 	"呼叫器关闭时可让好友呼叫",	/* DEF_FRIENDCALL */
 	"接受所有人的讯息",	/* DEF_ALLMSG */
 	"接受好友的讯息",	/* DEF_FRIENDMSG */
@@ -45,8 +45,7 @@ bbsparm_main()
 	html_header(1);
 	check_msg();
 	type = atoi(getparm("type"));
-	printf("<body><center><div class=rhead>%s -- 修改个人参数 [使用者: <span class=h11>%s</span>]</div><hr>\n", BBSNAME,
-	       currentuser.userid);
+	printf("<body><center><div class=rhead>%s -- 修改个人参数 [使用者: <span class=h11>%s</span>]</div><hr>\n", BBSNAME, currentuser.userid);
 	if (!loginok || isguest)
 		http_fatal("匆匆过客不能设定参数");
 	changemode(USERDEF);
@@ -60,14 +59,11 @@ bbsparm_main()
 			printf("<tr>\n");
 		if (currentuser.userdefine & perm)
 			ptr = " checked";
-		printf
-		    ("<td><input type=checkbox name=perm%d%s></td><td>%s</td>",
-		     i, ptr, defines[i]);
+		printf("<td><input type=checkbox name=perm%d%s></td><td>%s</td>", i, ptr, defines[i]);
 		perm = perm * 2;
 	}
 	printf("</table>");
-	printf
-	    ("<input type=submit value=确定修改></form><br>以上参数大多仅在telnet方式下才有作用\n");
+	printf("<input type=submit value=确定修改></form><br>以上参数大多仅在telnet方式下才有作用\n");
 	printf("</body>");
 	http_quit();
 	return 0;

--- a/nju09/www/bbspst.c
+++ b/nju09/www/bbspst.c
@@ -6,7 +6,7 @@ bbspst_main()
 {
 	FILE *fp;
 	int local_article, i, num, fullquote = 0, guestre = 0, thread = -1;
-	char userid[80], buf[512], path[512], file[512], board[512], title[80] = "";
+	char userid[IDLEN + 2], buf[512], path[512], file[20], board[32], title[80] = "";
 	struct fileheader *dirinfo = NULL;
 	struct boardmem *x;
 	//add by mintbaggio 040807 for new www
@@ -14,7 +14,7 @@ bbspst_main()
 	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 	check_msg();
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if(strcasecmp(board, "welcome") && strcasecmp(board, "KaoYan")){
 		// modify by mintbaggio 040614 for guest post at board "welcome" + "KaoYan"(by wsf)
 		if (!loginok) {
@@ -27,12 +27,11 @@ bbspst_main()
 	else if (seek_in_file(MY_BBS_HOME"/etc/guestbanip", fromhost) && !loginok)
 		http_fatal("您的ip被禁止使用guest在本版发表文章!");
 	local_article = 1; // modified by linux @ 2006.6.6 for the default post status to no outgo
-//	ytht_strsncpy(board, getparm("B"), 32);
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 20);
-	ytht_strsncpy(file, getparm("F"), 20);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 20);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	fullquote = atoi(getparm("fullquote"));
 	if (file[0] != 'M' && file[0])
 		http_fatal("错误的文件名");
@@ -56,12 +55,12 @@ bbspst_main()
 			thread = dirinfo->thread;
 			//if (dirinfo->accessed & FH_ALLREPLY)
 			//	guestre = 1;
-			ytht_strsncpy(userid, fh2owner(dirinfo), 20);
+			ytht_strsncpy(userid, fh2owner(dirinfo), sizeof(userid));
 			if (strncmp(dirinfo->title, "Re: ", 4)) {
-				snprintf(title, 60, "Re: %s", dirinfo->title);
+				snprintf(title, sizeof(title), "Re: %s", dirinfo->title);
 				local_article = atoi(getparm("la")); // added by linux @2006.6.6 for the post status to the status of the article before when doing a reply post
 			} else
-				ytht_strsncpy(title, dirinfo->title, 60);
+				ytht_strsncpy(title, dirinfo->title, sizeof(title));
 		} else
 			http_fatal("错误的文件名");
 		if (dirinfo->accessed & FH_NOREPLY)

--- a/nju09/www/bbspstmail.c
+++ b/nju09/www/bbspstmail.c
@@ -5,7 +5,7 @@ bbspstmail_main()
 {	//modify by mintbaggio 040821 for new www
 	FILE *fp;
 	int i, num, fullquote = 0;
-	char mymaildir[80], userid[80], buf[512], path[512], file[512], board[40], title[80] = "", buff[512];
+	char mymaildir[80], userid[80], buf[512], path[512], file[20], board[40], title[80] = "", buff[512];
 	struct fileheader *dirinfo;
 	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
@@ -28,9 +28,9 @@ bbspstmail_main()
 		ytht_strsncpy(board, getparm("board"), 32);
 	if (board[0] && !getboard(board))
 		http_fatal("错误的讨论区");
-	ytht_strsncpy(file, getparm("F"), 20);
+	ytht_strsncpy(file, getparm("F"), sizeof(file));
 	if (!file[0])
-		ytht_strsncpy(file, getparm("file"), 20);
+		ytht_strsncpy(file, getparm("file"), sizeof(file));
 	if (file[0] != 'M' && file[0])
 		http_fatal("错误的文件名");
 	if (file[0]) {
@@ -69,9 +69,9 @@ bbspstmail_main()
 				getdocauthor(buf, userid, sizeof (userid));
 			}
 			if (strncmp(dirinfo->title, "Re: ", 4))
-				snprintf(title, 55, "Re: %s", dirinfo->title);
+				snprintf(title, sizeof(title), "Re: %s", dirinfo->title);
 			else
-				ytht_strsncpy(title, dirinfo->title, 55);
+				ytht_strsncpy(title, dirinfo->title, sizeof(title));
 		} else
 			http_fatal("错误的文件名");
 	} else

--- a/nju09/www/bbspstmail.c
+++ b/nju09/www/bbspstmail.c
@@ -5,10 +5,9 @@ bbspstmail_main()
 {	//modify by mintbaggio 040821 for new www
 	FILE *fp;
 	int i, num, fullquote = 0;
-	char mymaildir[80], userid[80], buf[512], path[512], file[512],
-	    board[40], title[80] = "", buff[512];
+	char mymaildir[80], userid[80], buf[512], path[512], file[512], board[40], title[80] = "", buff[512];
 	struct fileheader *dirinfo;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 	check_msg();
 	if (!loginok)
@@ -51,8 +50,7 @@ bbspstmail_main()
 				if (mmapfile(buf, &mf) == -1)
 					dirinfo = NULL;
 				else {
-					dirinfo =
-					    findbarticle(&mf, file, &num, 1);
+					dirinfo = findbarticle(&mf, file, &num, 1);
 				}
 			}
 			MMAP_CATCH {
@@ -67,8 +65,7 @@ bbspstmail_main()
 					sprintf(buf, "boards/%s/%s", board,
 						fh2fname(dirinfo));
 				else
-					setmailfile(buf, currentuser.userid,
-						    fh2fname(dirinfo));
+					setmailfile_s(buf, sizeof(buf), currentuser.userid, fh2fname(dirinfo));
 				getdocauthor(buf, userid, sizeof (userid));
 			}
 			if (strncmp(dirinfo->title, "Re: ", 4))
@@ -96,63 +93,57 @@ bbspstmail_main()
 	printf("</script>\n");
 	printf("</head>");
 //	printf("<body><center>\n");
-/*	printf("%s -- 寄语信鸽 [使用者: %s]<hr>\n", BBSNAME,
-	       currentuser.userid);
+/*	printf("%s -- 寄语信鸽 [使用者: %s]<hr>\n", BBSNAME, currentuser.userid);
 	printf("<table border=1><tr><td>\n");
-	printf("<form name=form1 method=post action=bbssndmail?userid=%s>\n",
-	       userid);
-	printf
-	    ("信件标题: <input type=text name=title size=40 maxlength=100 value='%s'><br>",
-	     (noquote_html(title)));
+	printf("<form name=form1 method=post action=bbssndmail?userid=%s>\n", userid);
+	printf("信件标题: <input type=text name=title size=40 maxlength=100 value='%s'><br>", (noquote_html(title)));
 	printf("发信人: %s<br>\n", currentuser.userid);
-	printf
-	    ("收信人: <input type=text name=userid value='%s'> 发送给所有好友<input type=checkbox name=allfriend onclick=chguserid();>[<a href=bbsfall target=_blank>查看好友名单</a>]<br>",
-	     nohtml(userid));
+	printf("收信人: <input type=text name=userid value='%s'> 发送给所有好友<input type=checkbox name=allfriend onclick=chguserid();>[<a href=bbsfall target=_blank>查看好友名单</a>]<br>", nohtml(userid));
 	printselsignature();
 	printuploadattach();
 	printf(" 备份<input type=checkbox name=backup>\n");
 */
 	printf("<body>\n");
-	
+
 	/* 使用者ID */
 	printf("<div style=\"width: 100%%; height: 24px; text-align: center;\" class=\"level2\">\n");
 	printf("<p style=\"line-height: 24px;\">%s -- 寄语信鸽 [使用者: %s]</p>\n", BBSNAME, currentuser.userid);
 	printf("</div>\n");
-	
+
 	printf("<form style=\"margin-left: 20px; margin-top: 10px;\" name=\"form1\" method=\"post\" action=\"bbssndmail?userid=%s\">\n", userid);
 	printf("<table>\n");
-	
+
 	/* 一个pp的颜色条 */
 	printf("	<tr class=\"tdtitletheme\" style=\"height: 20px;\">\n");
 	printf("		<td colspan=\"3\">&nbsp;</td>\n");
 	printf("	</tr>\n");
-	
+
 	/* 标题的一行 */
 	printf("	<tr>\n");
 	printf("		<td>信件标题:</td>\n");
 	printf("		<td colspan=\"2\"><input id=titleedit name=\"title\" type=\"text\" size=\"40\" value=\"%s\"></td>\n", (noquote_html(title)));
 	printf("	</tr>\n");
-	
+
 	/* 发信人的一行 */
 	printf("	<tr height=\"20px\">\n");
 	printf("		<td>发信人:</td>\n");
 	printf("		<td colspan=\"1\">%s</td>\n", currentuser.userid);
-    //add 2014-11-23 save to sent-mail-box
-    printf("        <td><span>保存到发件箱</span><input type=\"checkbox\" name=\"backup\" checked></td>");
+	//add 2014-11-23 save to sent-mail-box
+	printf("        <td><span>保存到发件箱</span><input type=\"checkbox\" name=\"backup\" checked></td>");
 	printf("	</tr>\n");
-	
+
 	/* 收信人的一行 */
 	printf("	<tr>\n");
 	printf("		<td>收信人:</td>\n");
 	printf("		<td colspan=\"2\"><input name=\"userid\" type=\"text\" size=\"20\" value=\"%s\">\n", nohtml(userid));
 	printf("		<span style=\"margin-left: 60px;\">发送给所有好友<input type=\"checkbox\" name=\"allfriend\" onclick=\"chguserid();\">[ <a href=\"bbsfall\" target=\"_blank\">查看好友名单</a> ]</span></td>\n");
 	printf("	</tr>\n");
-	
+
 	/* 选择签名档，附件和引文模式的一行 */
 	printf("	<tr>\n");
 	printselsignature();
 	printuploadattach();
-	
+
 	/* 引文模式 */
 if (file[0]) {
 	printf("	<span style=\"margin-left: 20px;\">引文模式: %s ", fullquote ? "完全" : "精简");
@@ -163,7 +154,7 @@ if (file[0]) {
 
 	printf("</td>\n"); /* 弥补printselsignature()函数不封闭的</td> */
 	printf("	</tr>\n");
-	
+
 	/* 信件的正文内容 */
 	printf("	<tr>\n");
 	printf("		<td colspan=\"3\">\n");
@@ -195,8 +186,7 @@ if (file[0]) {
 					continue;
 				if (!strncmp(buf, "--\n", 3))
 					break;
-				if (!strncmp(buf, "begin 644 ", 10)
-				    || !strncmp(buf, "beginbinaryattach ", 18))
+				if (!strncmp(buf, "begin 644 ", 10) || !strncmp(buf, "beginbinaryattach ", 18))
 					break;
 				if (buf[0] == '\n')
 					continue;;
@@ -214,24 +204,24 @@ if (file[0]) {
 	printf("	</tr>\n");
 	if(file[0])
 		printf("<script language=\"JavaScript\">\n"
-			   " document.getElementById(\"textedit\").focus(); \n"
-			   "  </script>");
+				" document.getElementById(\"textedit\").focus(); \n"
+				"  </script>");
 	else
 		printf("<script language=\"JavaScript\">\n"
-			   " document.getElementById(\"titleedit\").focus(); \n"
-			   "  </script>");
-	
+				" document.getElementById(\"titleedit\").focus(); \n"
+				"  </script>");
+
 	/* 按钮的一行 */
 	printf("	<tr>\n");
 	printf("	<td colspan=\"3\">\n");
 	printf("		<input name=\"Submit2\" type=\"submit\" class=\"resetlong\" style=\"border: 1px solid #fff;\" value=\"发表\" onclick=\"this.value='信件发送中，请稍候...'; this.disabled=true;form1.submit();\">\n");
 	printf("		<input name=\"Submit3\" type=\"reset\" class=\"sumbitlong\" style=\"border: 1px solid #fff;\" value=\"清除\" onclick=\"return confirm('确定要全部清除吗?');\">\n");
 	printf("	</td>\n");
-	printf("	</tr>\n");	
+	printf("	</tr>\n");
 	printf("</table>\n");
 	printf("</form>\n"); /* 需要手动封闭？ */
 	printf("</body>\n"); /* 需要手动封闭？ */
-	
+
 	http_quit();
 	return 0;
 }

--- a/nju09/www/bbssig.c
+++ b/nju09/www/bbssig.c
@@ -1,5 +1,6 @@
 #include "bbslib.h"
-FILE *fp;
+
+static void save_sig(char *path);
 
 int
 bbssig_main()
@@ -10,16 +11,14 @@ bbssig_main()
 	if (!loginok || isguest)
 		http_fatal("匆匆过客不能设置签名档，请先登录");
 	changemode(EDITUFILE);
-	printf("<body><center><div class=rhead>%s -- 设置签名档 [使用者: <span class=h11>%s</span>]</div><hr>\n",
-	       BBSNAME, currentuser.userid);
-	sprintf(path, "home/%c/%s/signatures",
-		mytoupper(currentuser.userid[0]), currentuser.userid);
+	printf("<body><center><div class=rhead>%s -- 设置签名档 [使用者: <span class=h11>%s</span>]</div><hr>\n", BBSNAME, currentuser.userid);
+	sprintf(path, "home/%c/%s/signatures", mytoupper(currentuser.userid[0]), currentuser.userid);
 	if (!strcasecmp(getparm("type"), "1"))
 		save_sig(path);
 	printf("<form name=form1 method=post action=bbssig?type=1>\n");
 	printf("签名档每6行为一个单位, 可设置多个签名档.<br>"
-	       "(<a href=bbscon?B=Announce&F=M.1047666649.A>"
-	       "[临时公告]关于图片签名档的大小限制</a>)<br>");
+			"(<a href=bbscon?B=Announce&F=M.1047666649.A>"
+			"[临时公告]关于图片签名档的大小限制</a>)<br>");
 	printf("<textarea  onkeydown='if(event.keyCode==87 && event.ctrlKey) {document.form1.submit(); return false;}'  onkeypress='if(event.keyCode==10) return document.form1.submit()' name=text rows=20 cols=80>\n");
 	fp = fopen(path, "r");
 	if (fp) {
@@ -35,9 +34,8 @@ bbssig_main()
 	return 0;
 }
 
-void
-save_sig(char *path)
-{
+static void save_sig(char *path) {
+	FILE *fp;
 	char *buf;
 	fp = fopen(path, "w");
 	buf = getparm("text");

--- a/nju09/www/bbssnd.c
+++ b/nju09/www/bbssnd.c
@@ -20,15 +20,14 @@ testmath(char *ptr)
 int
 bbssnd_main()
 {
-	char filename[80], dir[80], board[80], title[80], buf[256], userid[20] ,*content,
-	    *ref, *content0;
+	char filename[80], dir[80], board[80], title[80], buf[256], userid[20] ,*content, *ref, *content0;
 	int r, sig, mark = 0, outgoing, anony, guestre = 0, usemath, nore, mailback;
 	int is1984, to1984 = 0;
 	size_t i;
 	struct boardmem *brd;
 	struct fileheader *x = NULL;
 	int thread = -1;
-	struct mmapfile mf = { ptr:NULL };
+	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 
 	ytht_strsncpy(board, getparm("board"), 18);
@@ -75,8 +74,7 @@ bbssnd_main()
 	} else {
 		thread = -1;
 	}
-	if(strcmp(board, "welcome") &&
-	   strcmp(board, "KaoYan")){	//add by mintbaggio 040614 for post at "welcome" + "KaoYan"(by wsf)
+	if(strcmp(board, "welcome") && strcmp(board, "KaoYan")){	//add by mintbaggio 040614 for post at "welcome" + "KaoYan"(by wsf)
 		if (!loginok || (isguest && !guestre))
 			http_fatal("匆匆过客不能发表文章，请先登录");
 	}
@@ -110,8 +108,7 @@ bbssnd_main()
 		mark |= FH_MAILREPLY;
 	if (title[0] == 0)
 		http_fatal("文章必须要有标题");
-	if(strcmp(board, "welcome") &&
-	   strcmp(board, "KaoYan")){   //add by mintbaggio 040614 for post at "welcome" + "KaoYan"(by wsf)
+	if(strcmp(board, "welcome") && strcmp(board, "KaoYan")){   //add by mintbaggio 040614 for post at "welcome" + "KaoYan"(by wsf)
 		if (!has_post_perm(&currentuser, brd) && !guestre)
 			http_fatal("此讨论区是唯读的, 或是您尚无权限在此发表文章.");
 	}
@@ -126,8 +123,7 @@ bbssnd_main()
 	sprintf(filename, "bbstmpfs/tmp/%d.tmp", thispid);
 	f_write(filename, content);
 	if (!hideboard_x(brd)) {
-		int dangerous =
-		    dofilter(title, filename, political_board(board));
+		int dangerous = dofilter(title, filename, political_board(board));
 		if (dangerous == 1){
 			to1984 = 1;
 			mail_file(filename, currentuser.userid, title, currentuser.userid);
@@ -135,8 +131,8 @@ bbssnd_main()
 			char mtitle[256];
 			sprintf(mtitle, "[发表报警] %s %.60s", board, title);
 			post_mail("delete", mtitle, filename,
-				  currentuser.userid, currentuser.username,
-				  fromhost, -1, 0);
+					currentuser.userid, currentuser.username,
+					fromhost, -1, 0);
 			updatelastpost("deleterequest");
 			mark |= FH_DANGEROUS;
 		}
@@ -150,17 +146,17 @@ bbssnd_main()
 
 	if (is1984 || to1984) {
 		r = post_article_1984(board, title, filename,
-				      currentuser.userid, currentuser.username,
-				      fromhost, sig - 1, mark, outgoing,
-				      currentuser.userid, thread);
+				currentuser.userid, currentuser.username,
+				fromhost, sig - 1, mark, outgoing,
+				currentuser.userid, thread);
 	} else if (anony)
 		r = post_article(board, title, filename, "Anonymous",
-				 "我是匿名天使", "匿名天使的家", 0, mark,
-				 outgoing, currentuser.userid, thread);
+				"我是匿名天使", "匿名天使的家", 0, mark,
+				outgoing, currentuser.userid, thread);
 	else
 		r = post_article(board, title, filename, currentuser.userid,
-				 currentuser.username, fromhost, sig - 1, mark,
-				 outgoing, currentuser.userid, thread);
+				currentuser.username, fromhost, sig - 1, mark,
+				outgoing, currentuser.userid, thread);
 	if (r <= 0)
 		http_fatal("内部错误，无法发文");
 	if (!is1984 && !to1984) {

--- a/nju09/www/bbssnd.c
+++ b/nju09/www/bbssnd.c
@@ -20,7 +20,7 @@ testmath(char *ptr)
 int
 bbssnd_main()
 {
-	char filename[80], dir[80], board[80], title[80], buf[256], userid[20] ,*content, *ref, *content0;
+	char filename[80], dir[80], board[32], title[80], buf[256], userid[20] ,*content, *ref, *content0;
 	int r, sig, mark = 0, outgoing, anony, guestre = 0, usemath, nore, mailback;
 	int is1984, to1984 = 0;
 	size_t i;
@@ -30,7 +30,7 @@ bbssnd_main()
 	struct mmapfile mf = { .ptr = NULL };
 	html_header(1);
 
-	ytht_strsncpy(board, getparm("board"), 18);
+	ytht_strsncpy(board, getparm("board"), sizeof(board));
 	ytht_strsncpy(title, getparm("title"), 60);
 	ytht_strsncpy(userid, getparm("replyto"), 14);
 	outgoing = strlen(getparm("outgoing"));
@@ -63,9 +63,9 @@ bbssnd_main()
 
 		if (x && (x->accessed & FH_ALLREPLY)) {
 			if (strncmp(x->title, "Re: ", 4))
-				snprintf(title, 60, "Re: %s", x->title);
+				snprintf(title, sizeof(title), "Re: %s", x->title);
 			else
-				snprintf(title, 60, "%s", x->title);
+				snprintf(title, sizeof(title), "%s", x->title);
 			guestre = 1;
 			mark = mark | FH_ALLREPLY;
 		}

--- a/nju09/www/bbssndmail.c
+++ b/nju09/www/bbssndmail.c
@@ -3,8 +3,7 @@
 int
 bbssndmail_main()
 {
-	char mymaildir[80], userid[80], filename[80], title[80], title2[80],
-	    *content;
+	char mymaildir[80], userid[80], filename[80], title[80], title2[80], *content;
 	int sig, backup, allfriend, mark = 0;
 	int lockfd;
 	size_t i;
@@ -44,7 +43,7 @@ bbssndmail_main()
 	if (!allfriend) {
 		snprintf(title2, sizeof (title2), "{%s} %s", userid, title);
 		post_mail(userid, title, filename, currentuser.userid,
-			  currentuser.username, fromhost, sig - 1, mark);
+				currentuser.username, fromhost, sig - 1, mark);
 	} else {
 		lockfd = ythtbbs_override_lock(currentuser.userid, YTHTBBS_OVERRIDE_FRIENDS);
 		ythtbbs_override_get_records(currentuser.userid, fff, MAXFRIENDS, YTHTBBS_OVERRIDE_FRIENDS);
@@ -65,7 +64,7 @@ bbssndmail_main()
 		post_mail_to_sent_box(currentuser.userid, title2, filename,
 				currentuser.userid, currentuser.username, fromhost,
 				sig - 1, mark);
-    }
+	}
 	unlink(filename);
 	printf("信件已寄给%s.<br>\n", allfriend ? "所有好友" : userid);
 	if (backup)

--- a/nju09/www/bbssndmail.c
+++ b/nju09/www/bbssndmail.c
@@ -3,13 +3,13 @@
 int
 bbssndmail_main()
 {
-	char mymaildir[80], userid[80], filename[80], title[80], title2[80], *content;
+	char mymaildir[80], userid[IDLEN + 2], filename[80], title[80], title2[80 * 2], *content;
 	int sig, backup, allfriend, mark = 0;
 	int lockfd;
 	size_t i;
 	struct userec *u;
 	html_header(1);
-	ytht_strsncpy(userid, getparm("userid"), 40);
+	ytht_strsncpy(userid, getparm("userid"), sizeof(userid));
 	if (!loginok || (isguest && strcmp(userid, "SYSOP")))
 		http_fatal("匆匆过客不能写信，请先登录");
 	if (HAS_PERM(PERM_DENYMAIL, currentuser))

--- a/nju09/www/bbstcon.c
+++ b/nju09/www/bbstcon.c
@@ -46,7 +46,7 @@ void tshare(char * board, int start, int thread, int article_count, char * owner
 int
 bbstcon_main()
 {	//modify by mintbaggio 040529 for new www, 041228 for www v2.0
-	char title[256], board[80], dir[80];
+	char title[256], board[32], dir[80];
 	char thread_title[256]; // 同主题标题 by IronBlood@bmy 20120426
 	char bmbuf[IDLEN * 4 + 4], odd_even_class[16], class[10];
 	struct fileheader *x;
@@ -60,7 +60,7 @@ bbstcon_main()
 	html_header(1);
 	check_msg();
 	printf("<script src=/function.js></script>\n");
-	ytht_strsncpy(board, getparm("board"), 32);
+	ytht_strsncpy(board, getparm("board"), sizeof(board));
 	thread = atoi(getparm("th"));
 	printf("<body leftmargin=0 topmargin=0>\n<img src=\"/images/bmy.gif\" style=\"position: absolute;top:-160px;\"/>\n");
 	printf("<table width=100%% border=0 cellpadding=0 cellspacing=0>\n");

--- a/nju09/www/bbstdoc.c
+++ b/nju09/www/bbstdoc.c
@@ -92,9 +92,9 @@ bbstdoc_main()
 				"<input name=start type=text style=\"font-size:11px;font-family:verdana;\" size=4>");
 		//add by liuche 20120206 for pagenumber
 		if((start-1)%w_info->t_lines==0)
-		printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+1,(total-1)/w_info->t_lines+1);
+			printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+1,(total-1)/w_info->t_lines+1);
 		else
-		printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+2,(total-1)/w_info->t_lines+1);
+			printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+2,(total-1)/w_info->t_lines+1);
 
 		//printhr();
 		printf("</td></tr></table></td></tr></table></td></tr></form></table>\n");
@@ -163,9 +163,9 @@ bbstdoc_main()
 	printf("<input name=Submit2 type=Submit class=sumbitgrey value=Go>\n"
 		"<input name=start type=text style=\"font-size:11px;font-family:verdana;\" size=4>");
 	if((start-1)%w_info->t_lines==0)
-	printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+1,(total-1)/w_info->t_lines+1);
+		printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+1,(total-1)/w_info->t_lines+1);
 	else
-	printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+2,(total-1)/w_info->t_lines+1);
+		printf(" Page: %d/%d\n",(start-1)/w_info->t_lines+2,(total-1)/w_info->t_lines+1);
 	printf("</td></tr></form></table>");
 	sprintf(buf, "%s", ytht_strtrim(x1->header.keyword));
 	if (strlen(buf)){

--- a/nju09/www/bbstdoc.c
+++ b/nju09/www/bbstdoc.c
@@ -14,15 +14,15 @@ extern void printrelationboards(char *buf);
 int
 bbstdoc_main()
 {
-	char board[80], buf[128],only_for_b[80],genbuf[STRLEN];
+	char board[32], buf[128],only_for_b[80],genbuf[STRLEN];
 	FILE *fp;
 	struct boardmem *x1;
 	struct fileheader *data = NULL;
 	int i, start = 0, total2 = 0, total = 0, sum = 0, fd, size;
 	changemode(READING);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	x1 = getboard(board);
 	if (x1 == 0) {
 		html_header(1);

--- a/nju09/www/bbstfind.c
+++ b/nju09/www/bbstfind.c
@@ -4,7 +4,7 @@ char *size_str(int size); // bbsdoc.c
 int
 bbstfind_main()
 {
-	char buf[1024], board[80], dir[80];
+	char buf[1024], board[32], dir[80];
 	struct boardmem *x1;
 	struct fileheader *x;
 	int i, total = 0, start = 0, numrecords;
@@ -13,9 +13,9 @@ bbstfind_main()
 	html_header(1);
 	check_msg();
 	changemode(READING);
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	thread = atoi(getparm("th"));
 	x1 = getboard(board);
 	if (x1 == 0)

--- a/nju09/www/bbsucss.c
+++ b/nju09/www/bbsucss.c
@@ -14,7 +14,7 @@ bbsucss_main()
 		else
 			return 0;
 	} else {
-		sethomefile(filename, currentuser.userid, path_info);
+		sethomefile_s(filename, sizeof(filename), currentuser.userid, path_info);
 /*		if (!file_exist(filename)){
 			if(!strcmp(path_info,"ubbs.css"))
 				strcpy(filename,HTMPATH CSSPATH"gres.css");

--- a/nju09/www/bbsvote.c
+++ b/nju09/www/bbsvote.c
@@ -16,7 +16,7 @@ bbsvote_main()
 	int aborted = NA, pos;
 	int i;
 	unsigned int j, multiroll = 0;
-	char board[80];
+	char board[32];
 	char controlfile[STRLEN];
 	char *date, *tmp1, *tmp2;
 	char flagname[STRLEN];
@@ -32,9 +32,9 @@ bbsvote_main()
 	struct boardmem *x;
 	html_header(1);
 	check_msg();
-	ytht_strsncpy(board, getparm("B"), 32);
+	ytht_strsncpy(board, getparm("B"), sizeof(board));
 	if (!board[0])
-		ytht_strsncpy(board, getparm("board"), 32);
+		ytht_strsncpy(board, getparm("board"), sizeof(board));
 	votenum = atoi(getparm("votenum"));
 	procvote = atoi(getparm("procvote"));
 	if (getboard(board) == NULL)
@@ -156,8 +156,7 @@ bbsvote_main()
 					printf("<input type=radio name=votesingle value=%d %s>%s<br>", (i + multiroll) % currvote.totalitems + 1, (j & 1) ? "checked" : "", currvote.items[(i + multiroll) % currvote.totalitems]);
 					j >>= 1;
 				}
-				printf
-				    ("<input type=hidden name=procvote value=2>");
+				printf("<input type=hidden name=procvote value=2>");
 				break;
 			case VOTE_MULTI:
 				j = (uservote.voted >> multiroll) + (uservote.voted << (currvote.totalitems - multiroll));
@@ -276,9 +275,7 @@ bbsvote_main()
 				ytht_strsncpy(buf1, getparm("sug"), 500);
 				tmp2 = buf1;
 				if (pos > 0)
-					uservote.msg[0][0] =
-					    uservote.msg[1][0] =
-					    uservote.msg[2][0] = 0;
+					uservote.msg[0][0] = uservote.msg[1][0] = uservote.msg[2][0] = 0;
 				for (i = 0; i < 3; i++) {
 					tmp1 = strchr(tmp2, '\n');
 					if (tmp1 != NULL)


### PR DESCRIPTION
目前 nju09 下还有少量的编译警告。大部分的编译警告类型：

* 缓冲区长度，例如 `board` 声明了 80 字节，其实复制只使用了 32 字节，而 BMY 目前最长的版面名称（英文）长度为 23（24-1）
* 函数原型，在之前的重构中已经移除了对 cproto 的依赖，但是一直没有仔细检查
* 缩进、使用安全的函数接口