### PR TITLE
Bughunting 20210227: 追加缓冲区大小调整

### DIFF
--- a/src/bbs/announce.c
+++ b/src/bbs/announce.c
@@ -484,7 +484,7 @@ int nomsg;
 	char fname[STRLEN], *ip, bname[PATHLEN];
 	char ans[5], filepath[PATHLEN];
 	MENU pm;
-	char anboard[STRLEN], tmpboard[STRLEN];
+	char anboard[24], tmpboard[24];
 
 	memset(&pm, 0, sizeof(MENU));
 	memset(anboard, 0, sizeof(anboard));
@@ -550,14 +550,14 @@ int nomsg;
 			a_prompt(-1, "已将该文章放进精华区, 请按<Enter>继续...", ans, 2);
 		}
 	if (!nomsg) {
-		strcpy(tmpboard, currboard);
-		strcpy(currboard, anboard);
+		ytht_strsncpy(tmpboard, currboard, sizeof(tmpboard));
+		ytht_strsncpy(currboard, anboard, sizeof(currboard));
 	}
 	snprintf(genbuf, 256, "%s import %s %s %s", currentuser.userid,
 		currboard, fileinfo->owner, fileinfo->title);
 	newtrace(genbuf);
 	if (!nomsg)
-		strcpy(currboard, tmpboard);
+		ytht_strsncpy(currboard, tmpboard, sizeof(currboard));
 	freeitem(&pm);
 	return 1;
 }

--- a/src/bbs/bbs.c
+++ b/src/bbs/bbs.c
@@ -1241,7 +1241,7 @@ super_select_board(char *bname)
 static int do_select(int ent, struct fileheader *fileinfo, char *direct) {
 	(void) ent;
 	(void) fileinfo;
-	char bname[STRLEN], bpath[STRLEN];
+	char bname[24], bpath[STRLEN];
 	struct stat st;
 	int ret;
 	struct boardmem *board;
@@ -1291,7 +1291,7 @@ static int do_select(int ent, struct fileheader *fileinfo, char *direct) {
 		board->inboard++;
 	selboard = 1;
 	brc_initial(bname, 0);
-	strcpy(currboard, bname);
+	ytht_strsncpy(currboard, bname, sizeof(currboard));
 
 	move(0, 0);
 	clrtoeol();

--- a/src/bbs/bbs.c
+++ b/src/bbs/bbs.c
@@ -2640,7 +2640,7 @@ import_spec()
 	int put_announce_flag;
 	char direct[STRLEN];
 	struct fileheader fileinfo;
-	char anboard[STRLEN], tmpboard[STRLEN];
+	char anboard[24], tmpboard[24];
 //   if(strcmp(currentuser.userid,"ecnegrevid")!=0) return DONOTHING;
 	if (digestmode == 2 || digestmode == 3
 			|| digestmode == 4 || digestmode == 5
@@ -2654,8 +2654,8 @@ import_spec()
 	if (fd == -1)
 		return FULLUPDATE;
 	put_announce_flag = !strcmp(currboard, anboard);
-	strcpy(tmpboard, currboard);
-	strcpy(currboard, anboard);
+	ytht_strsncpy(tmpboard, currboard, sizeof(tmpboard));
+	ytht_strsncpy(currboard, anboard, sizeof(currboard));
 	while (read(fd, &fileinfo, sizeof (fileinfo)) > 0) {
 		if (!(fileinfo.accessed & FH_SPEC))
 			continue;
@@ -2669,7 +2669,7 @@ import_spec()
 		if (write(fd, &fileinfo, sizeof (fileinfo)) < 0)
 			break;
 	}
-	strcpy(currboard, tmpboard);
+	ytht_strsncpy(currboard, tmpboard, sizeof(currboard));
 	close(fd);
 	return DIRCHANGED;
 }

--- a/src/bbs/vote.c
+++ b/src/bbs/vote.c
@@ -1580,12 +1580,12 @@ b_results()
 
 int m_vote(const char *s) {
 	(void) s;
-	char buf[STRLEN];
-	strcpy(buf, currboard);
-	strcpy(currboard, DEFAULTBOARD);
+	char buf[24];
+	ytht_strsncpy(buf, currboard, sizeof(buf));
+	ytht_strsncpy(currboard, DEFAULTBOARD, sizeof(currboard));
 	modify_user_mode(ADMIN);
 	vote_maintain(DEFAULTBOARD);
-	strcpy(currboard, buf);
+	ytht_strsncpy(currboard, buf, sizeof(currboard));
 	return 0;
 }
 

--- a/src/bbs/vote.c
+++ b/src/bbs/vote.c
@@ -169,7 +169,7 @@ char *fname;
 int
 b_closepolls()
 {
-	char buf[80];
+	char buf[24];
 	time_t now, nextpoll;
 	int i, end;
 
@@ -186,7 +186,7 @@ b_closepolls()
 
 	nextpoll = now + 7 * 3600;
 
-	strcpy(buf, currboard);
+	ytht_strsncpy(buf, currboard, sizeof(buf));
 	// TODO
 	for (i = 0; i < ythtbbs_cache_Board_get_number(); i++) {
 		setcontrolfile();
@@ -201,7 +201,7 @@ b_closepolls()
 				nextpoll = closetime + 300;
 		}
 	}
-	strcpy(currboard, buf);
+	ytht_strsncpy(currboard, buf, sizeof(currboard));
 	ythtbbs_cache_Board_set_pollvote(nextpoll);
 	return 0;
 }


### PR DESCRIPTION
修复 Coverity Scan 发现的 #153 引入的缺陷，由于调整全局变量 `currboard`（位于 `src/bbs/bbs.c`） 大小导致 8d6773afa57124ef553fd01038018204bee2bf90。