### PR TITLE
API / web 处理主题文章未读、已读

### DIFF
--- a/include/ythtbbs/boardrc.h
+++ b/include/ythtbbs/boardrc.h
@@ -25,7 +25,16 @@ struct allbrc {
 	char brc_c[BRC_MAXSIZE];
 };
 
-void brc_init(struct allbrc *allbrc, char *userid, char *filename);
+/**
+ * @brief 初始化 brc 记录
+ * 首先以只读方式打开位于 bbstmpfs 中的临时文件。
+ * 如果打开失败，再只读打开 brc_file。
+ * 文件打开后读取最多 BRC_MAXSIZE 的内容存放在 allbrc->brc_c 中。
+ * @param allbrc 用于存放记录的缓冲区
+ * @param userid
+ * @param brc_file 位于用户数据目录下的 brc 文件
+ */
+void brc_init(struct allbrc *allbrc, const char *userid, const char *brc_file);
 void brc_fini(struct allbrc *allbrc, char *userid);
 void brc_getboard(struct allbrc *allbrc, struct onebrc *brc, char *board);
 void brc_putboard(struct allbrc *allbrc, struct onebrc *brc);

--- a/include/ythtbbs/boardrc.h
+++ b/include/ythtbbs/boardrc.h
@@ -36,7 +36,16 @@ struct allbrc {
  */
 void brc_init(struct allbrc *allbrc, const char *userid, const char *brc_file);
 void brc_fini(struct allbrc *allbrc, char *userid);
-void brc_getboard(struct allbrc *allbrc, struct onebrc *brc, char *board);
+
+/**
+ * @brief 获取版面对应的阅读记录
+ * allbrc 中存放的是压缩后的数据，如果存在记录，则解压后存放在 brc 中。
+ * @param allbrc 压缩后的记录
+ * @param brc 用于存放解压后的数据
+ * @param board 查找的版面
+ * @warn 如果版面名称发生变化，则似乎会成为脏数据无法清理？ TODO
+ */
+void brc_getboard(const struct allbrc *allbrc, struct onebrc *brc, const char *board);
 void brc_putboard(struct allbrc *allbrc, struct onebrc *brc);
 void brc_addlistt(struct onebrc *brc, int t);
 int brc_unreadt(struct onebrc *brc, int t);

--- a/include/ythtbbs/boardrc.h
+++ b/include/ythtbbs/boardrc.h
@@ -1,6 +1,7 @@
 /* boardrc.c */
 #ifndef __BOADRC_H
 #define __BOADRC_H
+#include "ythtbbs/article.h"
 #define BRC_MAXSIZE     25000
 #define BRC_MAXNUM      60
 #define BRC_STRLEN      15
@@ -32,4 +33,6 @@ void brc_addlistt(struct onebrc *brc, int t);
 int brc_unreadt(struct onebrc *brc, int t);
 int brc_unreadt_quick(struct allbrc *allbrc, char *board, int t);
 void brc_clearto(struct onebrc *brc, int t);
+int UNREAD(const struct fileheader *fh, struct onebrc *brc);
+void SETREAD(const struct fileheader *fh, struct onebrc *brc);
 #endif

--- a/include/ythtbbs/cache.h
+++ b/include/ythtbbs/cache.h
@@ -63,7 +63,8 @@ struct user_info {
 	unsigned friend[MAXFRIENDS]; ///< 用于存放好友的 uid 列表
 	unsigned reject[MAXREJECTS]; ///< 用于存放黑名单的 uid 列表
 	struct wwwsession wwwinfo;
-	struct onebrc brc;
+	struct onebrc brc;           ///< 用于存放某个版面未读信息的数据，在 bbs / www 中使用
+	struct allbrc allbrc;        ///< 用于加载全部未读信息（压缩后的），在 api 中避免反复申请内存
 	char user_state_temp[16];  //add by leoncom
 };
 

--- a/include/ythtbbs/permissions.h
+++ b/include/ythtbbs/permissions.h
@@ -66,8 +66,6 @@
 #define HAS_PERM(x, _currentuser)    (((x)&PERM_SPECIAL3)?(_currentuser.dietime):((x)?_currentuser.userlevel&(x):1))
 #define HAS_CLUBRIGHT(x, clubrights) ((x)?(clubrights[x/32]&(1<<(x%32))):1)
 #define DEFINE(x, _currentuser)     ((x)?_currentuser.userdefine&(x):1)
-#define UNREAD(x, y) (((x)->edittime)?(brc_unreadt(y, (x)->edittime)):brc_unreadt(y, (x)->filetime))
-#define SETREAD(x, y) (((x)->edittime)?(brc_addlistt(y, (x)->edittime)):brc_addlistt(y, (x)->filetime))
 
 #define DEF_FRIENDCALL   000001
 #define DEF_ALLMSG       000002

--- a/libythtbbs/boardrc.c
+++ b/libythtbbs/boardrc.c
@@ -250,7 +250,9 @@ brc_putboard(struct allbrc *allbrc, struct onebrc *brc)
 	if (!brc->changed)
 		return;
 	brc->changed = 0;
-	tmpallbrc = malloc(sizeof (struct allbrc));
+	if ((tmpallbrc = calloc(1, sizeof (struct allbrc))) == NULL) {
+		return;
+	}
 	ptr1 = tmpallbrc->brc_c;
 	ptr10 = tmpallbrc->brc_c + sizeof (tmpallbrc->brc_c);
 	shorter_brc(brc);

--- a/libythtbbs/boardrc.c
+++ b/libythtbbs/boardrc.c
@@ -166,15 +166,13 @@ static void settmpbrc_s(char *filename, size_t len, const char *userid) {
 	snprintf(filename, len, "%s/%s", PATHTMPBRC, userid);
 }
 
-void
-brc_init(struct allbrc *allbrc, char *userid, char *filename)
-{
+void brc_init(struct allbrc *allbrc, const char *userid, const char *brc_file) {
 	int fd;
-	char filename1[80];
+	char brc_tmpfile[80];
 	allbrc->changed = 0;
-	settmpbrc_s(filename1, sizeof(filename1), userid);
-	if ((fd = open(filename1, O_RDONLY)) < 0) {
-		if (filename == NULL || (fd = open(filename, O_RDONLY)) < 0)
+	settmpbrc_s(brc_tmpfile, sizeof(brc_tmpfile), userid);
+	if ((fd = open(brc_tmpfile, O_RDONLY)) < 0) {
+		if (brc_file == NULL || (fd = open(brc_file, O_RDONLY)) < 0)
 			return;
 	}
 	allbrc->size = read(fd, allbrc->brc_c, BRC_MAXSIZE);

--- a/libythtbbs/boardrc.c
+++ b/libythtbbs/boardrc.c
@@ -64,11 +64,9 @@ compress_brc(struct onebrc_c *brc_c, struct onebrc *brc)
 	brc_c->len = ptr - (char *) brc_c;
 }
 
-static void
-uncompress_brc(struct onebrc *brc, struct onebrc_c *brc_c)
-{
+static void uncompress_brc(struct onebrc *brc, const struct onebrc_c *brc_c) {
 	int i, diff, bl, bh;
-	char *ptr, *bits;
+	const char *ptr, *bits;
 	brc->changed = 0;
 	ptr = brc_c->data;
 	ytht_strsncpy(brc->board, ptr, sizeof(brc->board));
@@ -200,21 +198,21 @@ brc_fini(struct allbrc *allbrc, char *userid)
 	allbrc->changed = 0;
 }
 
-void
-brc_getboard(struct allbrc *allbrc, struct onebrc *brc, char *board)
-{
-	char *ptr, *ptr0;
-	ptr0 = allbrc->brc_c + allbrc->size;
+void brc_getboard(const struct allbrc *allbrc, struct onebrc *brc, const char *board) {
+	const char *ptr /* 活动指针 */, *ptr0 /* 终止指针 */;
+	const struct onebrc_c *compressed;    // 分段压缩数据
+	ptr0 = allbrc->brc_c + allbrc->size;  // 计算结束地址
 	for (ptr = allbrc->brc_c; ptr < ptr0;) {
-		if (!((struct onebrc_c *) ptr)->len)
+		compressed = (const struct onebrc_c *) ptr;
+		if (!compressed->len)
 			break;
-		if (ptr + ((struct onebrc_c *) ptr)->len > ptr0)
+		if (ptr + compressed->len > ptr0)
 			break;
-		if (!strncmp(((struct onebrc_c *) ptr)->data, board, BRC_STRLEN - 1)) {
-			uncompress_brc(brc, (struct onebrc_c *) ptr);
+		if (!strncmp(compressed->data, board, BRC_STRLEN - 1)) {
+			uncompress_brc(brc, compressed);
 			return;
 		}
-		ptr += ((struct onebrc_c *) ptr)->len;
+		ptr += compressed->len; // 跳转到下一条压缩记录
 	}
 	strncpy(brc->board, board, BRC_STRLEN - 1);
 	brc->changed = 0;

--- a/libythtbbs/boardrc.c
+++ b/libythtbbs/boardrc.c
@@ -162,10 +162,8 @@ brc_c_unreadt(struct onebrc_c *brc_c, int t)
 	return 0;
 }
 
-static void
-settmpbrc(char *filename, char *userid)
-{
-	sprintf(filename, "%s/%s", PATHTMPBRC, userid);
+static void settmpbrc_s(char *filename, size_t len, const char *userid) {
+	snprintf(filename, len, "%s/%s", PATHTMPBRC, userid);
 }
 
 void
@@ -174,7 +172,7 @@ brc_init(struct allbrc *allbrc, char *userid, char *filename)
 	int fd;
 	char filename1[80];
 	allbrc->changed = 0;
-	settmpbrc(filename1, userid);
+	settmpbrc_s(filename1, sizeof(filename1), userid);
 	if ((fd = open(filename1, O_RDONLY)) < 0) {
 		if (filename == NULL || (fd = open(filename, O_RDONLY)) < 0)
 			return;
@@ -190,17 +188,17 @@ brc_fini(struct allbrc *allbrc, char *userid)
 {
 	int fd;
 	char filename1[80];
-	char tmpfile[80];
+	char tmpfile1[80];
 	if (!allbrc->changed)
 		return;
 	sprintf(filename1, "%s.tmp", userid);
-	settmpbrc(tmpfile, filename1);
-	if ((fd = open(tmpfile, O_WRONLY | O_CREAT, 0660)) < 0)
+	settmpbrc_s(tmpfile1, sizeof(tmpfile1), filename1);
+	if ((fd = open(tmpfile1, O_WRONLY | O_CREAT, 0660)) < 0)
 		return;
 	write(fd, allbrc->brc_c, allbrc->size);
 	close(fd);
-	settmpbrc(filename1, userid);
-	rename(tmpfile, filename1);
+	settmpbrc_s(filename1, sizeof(filename1), userid);
+	rename(tmpfile1, filename1);
 	allbrc->changed = 0;
 }
 

--- a/libythtbbs/boardrc.c
+++ b/libythtbbs/boardrc.c
@@ -365,3 +365,11 @@ brc_clearto(struct onebrc *brc, int t)
 	brc_set(brc, t);
 }
 
+int UNREAD(const struct fileheader *fh, struct onebrc *brc) {
+	return brc_unreadt(brc, fh->edittime ? fh->edittime : fh->filetime);
+}
+
+void SETREAD(const struct fileheader *fh, struct onebrc *brc) {
+	brc_addlistt(brc, fh->edittime ? fh->edittime : fh->filetime);
+}
+

--- a/web/src/components/ArticleViewer.vue
+++ b/web/src/components/ArticleViewer.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="card border-bmy-blue1 mb-4">
+	<div class="card border-bmy-blue1 mb-4" :class="{ 'unread-shadow': _unread > 0 }">
 		<div class="card-header bg-bmy-blue0 bg-gradient">
 			<div class="d-flex">
 				<span class="fw-bold text-bmy-dark8">{{ title }}</span>
@@ -73,6 +73,7 @@ export default {
 		_boardname_en: String,
 		_aid: Number,
 		_mark: Number,
+		_unread: Number,
 		_reply_callback: Function,
 	},
 	mounted() {
@@ -212,6 +213,10 @@ export default {
 	font-weight: 700;
 	padding: 0.3rem 0.8rem;
 	border: 2px solid var(--bs-bmy-grey2);
+}
+
+.unread-shadow {
+	box-shadow: 0px 2px 10px 1px rgba(0,76,151,0.20);
 }
 
 </style>

--- a/web/src/components/BoardArticleListItem.vue
+++ b/web/src/components/BoardArticleListItem.vue
@@ -1,5 +1,5 @@
 <template>
-	<li class="list-group-item border-bmy-blue">
+	<li class="list-group-item border-bmy-blue" :class="{ 'bg-bmy-blue0': _unread > 0 }">
 		<div class="d-flex">
 			<router-link :to="{ name: 'thread', params: { boardname: _boardname_en, tid: _aid }}" class="fs-5 text-bmy-dark8 text-decoration-none">{{ _title }}</router-link>
 			<BadgeArticleFlags :_accessed="_accessed" />
@@ -36,6 +36,7 @@ export default {
 		_comments: Number,
 		_aid: Number,
 		_accessed: Number,
+		_unread: Number,
 	},
 	components: {
 		BadgeArticleFlags,

--- a/web/src/views/BoardView.vue
+++ b/web/src/views/BoardView.vue
@@ -12,6 +12,7 @@
 					v-bind:_comments="article.th_num"
 					v-bind:_aid="article.tid"
 					v-bind:_accessed="article.mark"
+					v-bind:_unread="article.unread"
 				/>
 			</ul>
 		</div>

--- a/web/src/views/Thread.vue
+++ b/web/src/views/Thread.vue
@@ -5,6 +5,7 @@
 			v-bind:_boardname_en="$route.params.boardname"
 			v-bind:_aid="article.aid"
 			v-bind:_mark="article.mark"
+			v-bind:_unread="article.unread"
 			v-bind:_reply_callback="updateList"
 		/>
 	</div>


### PR DESCRIPTION
目前显示主要在：
1. 版面主题列表依据同列表最新发表或编辑判断，使用 `bg-bmy-blue0` 背景色
2. 主题阅读列表，使用 `box-shadow` 高亮未读文章

订阅、分区方式由于数据库字段缺失，这次暂未实现。